### PR TITLE
feat: improve HubEvmSpokeVoteDecoder testing with actual contract call responses

### DIFF
--- a/evm/test/HubEvmSpokeVoteDecoder.t.sol
+++ b/evm/test/HubEvmSpokeVoteDecoder.t.sol
@@ -53,8 +53,8 @@ contract HubEvmSpokeVoteDecoderTest is WormholeEthQueryTest, AddressUtils {
     _setupWormhole();
 
     address initialOwner = makeAddr("Initial Owner");
-    address hubVotePoolOwner = initialOwner;
     timelock = new TimelockControllerFake(initialOwner);
+    address hubVotePoolOwner = address(timelock);
     token = new ERC20VotesFake();
 
     extender = new HubProposalExtender(initialOwner, VOTE_TIME_EXTENSION, initialOwner, MINIMUM_VOTE_EXTENSION);
@@ -67,7 +67,7 @@ contract HubEvmSpokeVoteDecoderTest is WormholeEthQueryTest, AddressUtils {
       initialVotingPeriod: INITIAL_VOTING_PERIOD,
       initialProposalThreshold: PROPOSAL_THRESHOLD,
       initialQuorum: INITIAL_QUORUM,
-      hubVotePoolOwner: address(timelock),
+      hubVotePoolOwner: hubVotePoolOwner,
       wormholeCore: address(wormhole),
       governorProposalExtender: address(extender),
       initialVoteWeightWindow: VOTE_WEIGHT_WINDOW


### PR DESCRIPTION
## Description

To enhance the accuracy and reliability of our testing, we are now using actual contract call responses to build relevant Wormhole mock query responses. 

The HubEvmSpokeVoteDecoder tests haven been updated accordingly in this pr, making them more realistic.

Other places in the contracts where we mock queries will also be updated in other pr's. 

Improvements:

1. Proposal Creation Setup: Now using actual metadata from the HubProposalMetadata contract.
2. Vote Queries: Retrieving actual vote data from the SpokeVoteAggregator contract instead of using hardcoded values.
3. Query Response Building: Constructing query responses based on actual contract states and responses.
4. Test Assertions: Comparing decoded query votes against actual contract data for validation.

Changes:

- Updated `_buildAddProposalQuery` to use real proposal metadata.
- Refactored `_buildVoteQueryResponse` and related functions to use actual vote data from SpokeVoteAggregator.
- Modified `testFuzz_CorrectlyParseChainResponse` to use real proposal and vote data.
- Updated `_assertVoteResults` to compare against actual contract vote counts.