### PR TITLE
[evm] fix: audit 7.2.1 - remove unnecessary else

### DIFF
--- a/evm/src/HubSolanaSpokeVoteDecoder.sol
+++ b/evm/src/HubSolanaSpokeVoteDecoder.sol
@@ -169,7 +169,7 @@ contract HubSolanaSpokeVoteDecoder is ISpokeVoteDecoder, QueryResponse, ERC165 {
     if (_fromDecimals == _toDecimals) return _amount;
 
     if (_fromDecimals > _toDecimals) return _amount / (10 ** (_fromDecimals - _toDecimals));
-    else return _amount * (10 ** (_toDecimals - _fromDecimals));
+    return _amount * (10 ** (_toDecimals - _fromDecimals));
   }
 
   /// @notice Reverse the endianness of the passed in integer.


### PR DESCRIPTION
Removes unnecessary else in scale function in `HubSolanaSpokeVoteDecoder`.