### PR TITLE
[solana] Handle window length timestamp collision

### DIFF
--- a/solana/programs/staking/src/state/vote_weight_window_lengths.rs
+++ b/solana/programs/staking/src/state/vote_weight_window_lengths.rs
@@ -99,6 +99,7 @@ pub fn push_new_window_length<'info>(
     let (current_index, latest_timestamp) = {
         let vote_weight_window_length = vote_weight_window_length_loader.load()?;
         if vote_weight_window_length.next_index == 0 {
+            // NOTE: this should never happen as we initialize vote_weight_window_length with next_index set to 1
             (0, None) // if next_index is 0, set latest_timestamp to None
         } else {
             let latest_window_length = read_window_length_at_index(


### PR DESCRIPTION
* Handle timestamp collision in `push_new_window_length` function by employing simplified [push_checkpoint](https://github.com/wormhole-foundation/multigov-ext-audit-fixes/blob/main/solana/programs/staking/src/state/checkpoints.rs#L137) logic


#### Function logic:
- Fetch `current_index` and `latest_timestamp`
- If `latest_timestamp == current_timestamp`: overwrite (at `current_index - 1`) with new `window_length`
- Else: update `next_index`, resize if needed, and insert (at `current_index`) new `window_length`