### PR TITLE
[solana] Mark `refund_recipient` account as writable

### DIFF
--- a/solana/programs/staking/src/context.rs
+++ b/solana/programs/staking/src/context.rs
@@ -273,7 +273,7 @@ pub struct CloseSignatures<'info> {
     #[account(mut, has_one = refund_recipient, close = refund_recipient)]
     pub guardian_signatures: Account<'info, GuardianSignatures>,
 
-    #[account(address = guardian_signatures.refund_recipient)]
+    #[account(mut, address = guardian_signatures.refund_recipient)]
     pub refund_recipient: Signer<'info>,
 }
 
@@ -297,7 +297,7 @@ pub struct AddProposal<'info> {
     pub guardian_signatures: Account<'info, GuardianSignatures>,
 
     /// CHECK: This account is the refund recipient for the above signature_set
-    #[account(address = guardian_signatures.refund_recipient)]
+    #[account(mut, address = guardian_signatures.refund_recipient)]
     pub refund_recipient: AccountInfo<'info>,
 
     #[account(mut)]


### PR DESCRIPTION
This PR updates `refund_recipient` account as `mut` in `AddProposal` and `CloseSignatures` instructions