### PR TITLE
[evm] HubVotePool: Spoke vote limiter

### DIFF
--- a/evm/script/DeployHubContractsBaseImpl.s.sol
+++ b/evm/script/DeployHubContractsBaseImpl.s.sol
@@ -73,7 +73,7 @@ abstract contract DeployHubContractsBaseImpl is Script {
     );
 
     // Deploy `HubVotePool` which will revceive cross-chain votes.
-    HubVotePool hubVotePool = new HubVotePool(config.wormholeCore, address(0), wallet.addr);
+    HubVotePool hubVotePool = new HubVotePool(config.wormholeCore, address(0), wallet.addr, wallet.addr);
 
     HubGovernor.ConstructorParams memory hubGovernorParams = HubGovernor.ConstructorParams({
       name: config.name,

--- a/evm/test/HubEvmSpokeAggregateProposer.t.sol
+++ b/evm/test/HubEvmSpokeAggregateProposer.t.sol
@@ -53,8 +53,9 @@ contract HubEvmSpokeAggregateProposerTest is WormholeEthQueryTest, AddressUtils,
     address initialOwner = makeAddr("Initial Owner");
     timelock = new TimelockControllerFake(initialOwner);
     token = new ERC20VotesFake();
+    address guardianContract = makeAddr("Guardian Contract");
 
-    hubVotePool = new HubVotePool(address(wormhole), initialOwner, address(timelock));
+    hubVotePool = new HubVotePool(address(wormhole), initialOwner, address(timelock), guardianContract);
 
     extender = new HubProposalExtender(
       initialOwner, VOTE_TIME_EXTENSION, address(timelock), address(timelock), MINIMUM_VOTE_EXTENSION

--- a/evm/test/HubEvmSpokeVoteDecoder.t.sol
+++ b/evm/test/HubEvmSpokeVoteDecoder.t.sol
@@ -26,6 +26,7 @@ contract HubEvmSpokeVoteDecoderTest is WormholeEthQueryTest, AddressUtils {
   HubEvmSpokeVoteDecoder hubCrossChainEvmVote;
   HubVotePoolHarness hubVotePool;
   address timelock;
+  address guardianContract;
 
   struct VoteParams {
     uint256 proposalId;
@@ -38,7 +39,8 @@ contract HubEvmSpokeVoteDecoderTest is WormholeEthQueryTest, AddressUtils {
     _setupWormhole();
     governor = new GovernorMock();
     timelock = makeAddr("Timelock");
-    hubVotePool = new HubVotePoolHarness(address(wormhole), address(governor), timelock);
+    guardianContract = makeAddr("Guardian Contract");
+    hubVotePool = new HubVotePoolHarness(address(wormhole), address(governor), timelock, guardianContract);
     hubCrossChainEvmVote = new HubEvmSpokeVoteDecoder(address(wormhole), address(hubVotePool));
   }
 

--- a/evm/test/HubGovernor.t.sol
+++ b/evm/test/HubGovernor.t.sol
@@ -27,6 +27,7 @@ contract HubGovernorTest is WormholeEthQueryTest, ProposalTest {
   HubProposalExtender public extender;
 
   address initialOwner;
+  address guardianContract;
 
   uint48 constant VOTE_WEIGHT_WINDOW = 1 days;
   uint48 constant MINIMUM_VOTE_EXTENSION = 1 hours;
@@ -40,8 +41,9 @@ contract HubGovernorTest is WormholeEthQueryTest, ProposalTest {
     extender = new HubProposalExtender(
       initialOwner, VOTE_TIME_EXTENSION, address(timelock), initialOwner, MINIMUM_VOTE_EXTENSION
     );
+    guardianContract = makeAddr("Guardian Contract");
 
-    hubVotePool = new HubVotePoolHarness(address(wormhole), initialOwner, address(timelock));
+    hubVotePool = new HubVotePoolHarness(address(wormhole), initialOwner, address(timelock), guardianContract);
 
     HubGovernor.ConstructorParams memory params = HubGovernor.ConstructorParams({
       name: "Example Gov",
@@ -178,17 +180,19 @@ contract Constructor is HubGovernorTest {
     uint208 _initialProposalThreshold,
     uint208 _initialQuorum,
     address _extenderOwner,
-    address _deployer
+    address _deployer,
+    address _guardianContract
   ) public {
     vm.assume(_initialVotingPeriod != 0);
     vm.assume(_extenderOwner != address(0) && _timelock != address(0));
     vm.assume(_extenderOwner != address(_timelock));
     vm.assume(_deployer != address(0));
+    vm.assume(_guardianContract != address(0));
 
     HubProposalExtender _voteExtender = new HubProposalExtender(
       initialOwner, VOTE_TIME_EXTENSION, address(_extenderOwner), _deployer, MINIMUM_VOTE_EXTENSION
     );
-    HubVotePool hubVotePool = new HubVotePool(address(wormhole), address(0), address(timelock));
+    HubVotePool hubVotePool = new HubVotePool(address(wormhole), address(0), address(timelock), _guardianContract);
 
     HubGovernor.ConstructorParams memory params = HubGovernor.ConstructorParams({
       name: _name,

--- a/evm/test/HubProposalMetadata.t.sol
+++ b/evm/test/HubProposalMetadata.t.sol
@@ -39,7 +39,8 @@ contract HubProposalMetadataTest is Test, ProposalTest {
     extender = new HubProposalExtender(
       initialOwner, VOTE_TIME_EXTENSION, address(timelock), initialOwner, MINIMUM_VOTE_EXTENSION
     );
-    HubVotePool hubVotePool = new HubVotePool(address(wormhole), address(0), address(timelock));
+    address guardianContract = makeAddr("Guardian Contract");
+    HubVotePool hubVotePool = new HubVotePool(address(wormhole), address(0), address(timelock), guardianContract);
     HubGovernor.ConstructorParams memory params = HubGovernor.ConstructorParams({
       name: "Example Gov",
       token: token,

--- a/evm/test/HubSolanaSpokeVoteDecoder.t.sol
+++ b/evm/test/HubSolanaSpokeVoteDecoder.t.sol
@@ -48,12 +48,13 @@ contract HubSolanaSpokeVoteDecoderTest is WormholeEthQueryTest, AddressUtils {
     timelock = new TimelockControllerFake(initialOwner);
     address hubVotePoolOwner = address(timelock);
     token = new ERC20VotesFake();
+    address guardianContract = makeAddr("Guardian Contract");
 
     extender = new HubProposalExtender(
       initialOwner, VOTE_TIME_EXTENSION, address(timelock), initialOwner, MINIMUM_VOTE_EXTENSION
     );
 
-    hubVotePool = new HubVotePoolHarness(address(wormhole), address(0), hubVotePoolOwner);
+    hubVotePool = new HubVotePoolHarness(address(wormhole), address(0), hubVotePoolOwner, guardianContract);
 
     HubGovernor.ConstructorParams memory params = HubGovernor.ConstructorParams({
       name: "Test Gov",

--- a/evm/test/harnesses/HubVotePoolHarness.sol
+++ b/evm/test/harnesses/HubVotePoolHarness.sol
@@ -4,5 +4,7 @@ pragma solidity ^0.8.23;
 import {HubVotePool} from "src/HubVotePool.sol";
 
 contract HubVotePoolHarness is HubVotePool {
-  constructor(address _core, address _hubGovernor, address _timelock) HubVotePool(_core, _hubGovernor, _timelock) {}
+  constructor(address _core, address _hubGovernor, address _timelock, address _guardianContract)
+    HubVotePool(_core, _hubGovernor, _timelock, _guardianContract)
+  {}
 }


### PR DESCRIPTION
A defence in depth measure to allow a permissioned entity to set the maximum voting power for each spoke.

This is intended to be a temporary measure, and it can be easily reversed by pulling out this commit (or alternatively this commit lives on a fork), redeploying the HubVotePool without these change, and creating and executing a proposal to update the HubVotePool the HubGovernor points to.

The intended permissioned entity is the Wormhole Governance contract controlled by the Guardians, but initially the entity is decided by the deployer to allow for an initial sensible configuration based on the current distribution of tokens.