### PR TITLE
[solana] Remove self call airlock

### DIFF
--- a/solana/app/deploy/03_create_airlock.ts
+++ b/solana/app/deploy/03_create_airlock.ts
@@ -28,18 +28,12 @@ async function main() {
       program.programId,
     )[0];
 
-    const airlockSelfCallPDA: PublicKey = PublicKey.findProgramAddressSync(
-      [Buffer.from("airlock_self_call")],
-      program.programId,
-    )[0];
-
     await program.methods
       .initializeSpokeAirlock()
       .accounts({
         payer: DEPLOYER_AUTHORITY_KEYPAIR.publicKey,
         // @ts-ignore
         airlock: airlockPDA,
-        airlockSelfCall: airlockSelfCallPDA,
         systemProgram: SystemProgram.programId,
       })
       .rpc({ skipPreflight: DEBUG });

--- a/solana/app/deploy/receive_message.ts
+++ b/solana/app/deploy/receive_message.ts
@@ -67,11 +67,6 @@ async function main() {
       program.programId,
     )[0];
 
-    const airlockSelfCallPDA: PublicKey = PublicKey.findProgramAddressSync(
-      [Buffer.from("airlock_self_call")],
-      program.programId,
-    )[0];
-
     // Prepare the messageReceivedPDA seeds
     const messageReceivedSeed = Buffer.from("message_received");
     const emitterChainSeed = Buffer.alloc(HUB_CHAIN_ID);
@@ -95,7 +90,6 @@ async function main() {
         // @ts-ignore
         messageReceived: messageReceivedPDA,
         airlock: airlockPDA,
-        airlockSelfCall: airlockSelfCallPDA,
         messageExecutor: messageExecutorPDA,
         postedVaa: POSTED_VAA_ADDRESS,
         wormholeProgram: CORE_BRIDGE_PID,

--- a/solana/programs/staking/src/context.rs
+++ b/solana/programs/staking/src/context.rs
@@ -30,7 +30,6 @@ pub const VESTING_BALANCE_SEED: &str = "vesting_balance";
 pub const SPOKE_MESSAGE_EXECUTOR_SEED: &str = "spoke_message_executor";
 pub const MESSAGE_RECEIVED: &str = "message_received";
 pub const AIRLOCK_SEED: &str = "airlock";
-pub const AIRLOCK_SELF_CALL_SEED: &str = "airlock_self_call";
 pub const SPOKE_METADATA_COLLECTOR_SEED: &str = "spoke_metadata_collector";
 pub const VOTE_WEIGHT_WINDOW_LENGTHS_SEED: &str = "vote_weight_window_lengths";
 pub const GUARDIAN_SIGNATURES_SEED: &str = "guardian_signatures";
@@ -218,10 +217,10 @@ pub struct UpdateHubProposalMetadata<'info> {
     pub payer: Signer<'info>,
 
     #[account(
-        seeds = [AIRLOCK_SELF_CALL_SEED.as_bytes()],
-        bump = airlock_self_call.bump,
+        seeds = [AIRLOCK_SEED.as_bytes()],
+        bump = airlock.bump,
     )]
-    pub airlock_self_call: Account<'info, SpokeAirlock>,
+    pub airlock: Account<'info, SpokeAirlock>,
 
     #[account(
         mut,
@@ -684,12 +683,6 @@ pub struct ReceiveMessage<'info> {
     pub airlock: Box<Account<'info, SpokeAirlock>>,
 
     #[account(
-        seeds = [AIRLOCK_SELF_CALL_SEED.as_bytes()],
-        bump = airlock_self_call.bump,
-    )]
-    pub airlock_self_call: Box<Account<'info, SpokeAirlock>>,
-
-    #[account(
         seeds = [SPOKE_MESSAGE_EXECUTOR_SEED.as_bytes()],
         bump = message_executor.bump,
         constraint = message_executor.wormhole_core == wormhole_program.key() @ MessageExecutorError::InvalidWormholeCoreProgram
@@ -718,15 +711,6 @@ pub struct InitializeSpokeAirlock<'info> {
         bump
     )]
     pub airlock: Account<'info, SpokeAirlock>,
-
-    #[account(
-        init,
-        payer = payer,
-        space = SpokeAirlock::LEN,
-        seeds = [AIRLOCK_SELF_CALL_SEED.as_bytes()],
-        bump
-    )]
-    pub airlock_self_call: Account<'info, SpokeAirlock>,
     pub system_program: Program<'info, System>,
 }
 
@@ -757,11 +741,11 @@ pub struct UpdateVoteWeightWindowLengths<'info> {
     pub payer: Signer<'info>,
 
     #[account(
-        seeds = [AIRLOCK_SELF_CALL_SEED.as_bytes()],
-        bump = airlock_self_call.bump,
+        seeds = [AIRLOCK_SEED.as_bytes()],
+        bump = airlock.bump,
         signer
     )]
-    pub airlock_self_call: Account<'info, SpokeAirlock>,
+    pub airlock: Account<'info, SpokeAirlock>,
 
     #[account(
         mut,

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -825,19 +825,10 @@ pub mod staking {
                 data: instruction.data.clone(),
             };
 
-            // Use invoke_signed with the correct signer_seeds
-            if ix.program_id != crate::ID {
-                let signer_seeds: &[&[&[u8]]] =
-                    &[&[AIRLOCK_SEED.as_bytes(), &[ctx.accounts.airlock.bump]]];
+            let signer_seeds: &[&[&[u8]]] =
+                &[&[AIRLOCK_SEED.as_bytes(), &[ctx.accounts.airlock.bump]]];
 
-                invoke_signed(&ix, &account_infos, signer_seeds)?;
-            }
-            else  {
-                let signer_seeds: &[&[&[u8]]] =
-                    &[&[AIRLOCK_SELF_CALL_SEED.as_bytes(), &[ctx.accounts.airlock_self_call.bump]]];
-
-                invoke_signed(&ix, &account_infos, signer_seeds)?;
-            }
+            invoke_signed(&ix, &account_infos, signer_seeds)?;
         }
 
         let balance_after = ctx.accounts.payer.lamports();
@@ -858,9 +849,7 @@ pub mod staking {
     //------------------------------------ ------------------------------------------------
     pub fn initialize_spoke_airlock(ctx: Context<InitializeSpokeAirlock>) -> Result<()> {
         let airlock = &mut ctx.accounts.airlock;
-        let airlock_self_call = &mut ctx.accounts.airlock_self_call;
         airlock.bump = ctx.bumps.airlock;
-        airlock_self_call.bump = ctx.bumps.airlock_self_call;
         Ok(())
     }
 
@@ -893,7 +882,7 @@ pub mod staking {
             require!(ctx.accounts.payer.key() == ctx.accounts.config.governance_authority, ErrorCode::NotGovernanceAuthority);
         }
         else {
-            require!(ctx.accounts.airlock_self_call.to_account_info().is_signer, ErrorCode::AirlockNotSigner);
+            require!(ctx.accounts.airlock.to_account_info().is_signer, ErrorCode::AirlockNotSigner);
         }
 
         let _ = spoke_metadata_collector.update_hub_proposal_metadata(new_hub_proposal_metadata);

--- a/solana/tests/executor.ts
+++ b/solana/tests/executor.ts
@@ -68,7 +68,6 @@ describe("receive_message", () => {
   let controller;
   let payer: Keypair;
   let airlockPDA: PublicKey;
-  let selfCallAirlockPDA: PublicKey;
   let messageExecutorPDA: PublicKey;
   let messageExecutor: PublicKey;
   let externalProgram: Program<ExternalProgram>;
@@ -113,11 +112,6 @@ describe("receive_message", () => {
       stakeConnection.program.programId,
     );
 
-    [selfCallAirlockPDA] = PublicKey.findProgramAddressSync(
-      [Buffer.from("airlock_self_call")],
-      stakeConnection.program.programId,
-    );
-
     [messageExecutorPDA] = PublicKey.findProgramAddressSync(
       [Buffer.from("spoke_message_executor")],
       stakeConnection.program.programId,
@@ -129,7 +123,6 @@ describe("receive_message", () => {
       .accounts({
         payer: payer.publicKey,
         airlock: airlockPDA,
-        airlockSelfCall: selfCallAirlockPDA,
         systemProgram: SystemProgram.programId,
       })
       .signers([payer])
@@ -195,7 +188,6 @@ describe("receive_message", () => {
           payer: payer.publicKey,
           messageReceived: messageReceivedPDA,
           airlock: airlockPDA,
-          airlockSelfCall: selfCallAirlockPDA,
           messageExecutor: messageExecutorPDA,
           postedVaa: publicKey,
           wormholeProgram: CORE_BRIDGE_PID,
@@ -250,7 +242,6 @@ describe("receive_message", () => {
         payer: payer.publicKey,
         messageReceived: messageReceivedPDA,
         airlock: airlockPDA,
-        airlockSelfCall: selfCallAirlockPDA,
         messageExecutor: messageExecutorPDA,
         postedVaa: publicKey,
         wormholeProgram: CORE_BRIDGE_PID,
@@ -299,7 +290,6 @@ describe("receive_message", () => {
           payer: payer.publicKey,
           messageReceived: messageReceivedPDA,
           airlock: airlockPDA,
-          airlockSelfCall: selfCallAirlockPDA,
           messageExecutor: messageExecutorPDA,
           postedVaa: publicKey,
           wormholeProgram: CORE_BRIDGE_PID,
@@ -368,7 +358,6 @@ describe("receive_message", () => {
         payer: payer.publicKey,
         messageReceived: messageReceivedPDA,
         airlock: airlockPDA,
-        airlockSelfCall: selfCallAirlockPDA,
         messageExecutor: messageExecutorPDA,
         postedVaa: publicKey,
         wormholeProgram: CORE_BRIDGE_PID,
@@ -394,7 +383,6 @@ describe("receive_message", () => {
       await generateUpdateVoteWeightWindowLengthsInstruction(
         stakeConnection,
         airlockPDA,
-        selfCallAirlockPDA,
         new BN(windowLength),
       );
 
@@ -424,8 +412,7 @@ describe("receive_message", () => {
     );
 
     let remainingAccountsModified = remainingAccounts.map((a) => {
-      if (a.pubkey.toBase58() === airlockPDA.toBase58()
-        || a.pubkey.toBase58() === selfCallAirlockPDA.toBase58()) {
+      if (a.pubkey.toBase58() === airlockPDA.toBase58()) {
         return {
           pubkey: a.pubkey,
           isWritable: a.isWritable,
@@ -442,7 +429,6 @@ describe("receive_message", () => {
           payer: payer.publicKey,
           messageReceived: messageReceivedPDA,
           airlock: airlockPDA,
-          airlockSelfCall: selfCallAirlockPDA,
           messageExecutor: messageExecutorPDA,
           postedVaa: publicKey,
           wormholeProgram: CORE_BRIDGE_PID,
@@ -467,7 +453,6 @@ describe("receive_message", () => {
       await generateUpdateVoteWeightWindowLengthsInstruction(
         stakeConnection,
         airlockPDA,
-        selfCallAirlockPDA,
         new BN(windowLength),
       );
 
@@ -497,8 +482,7 @@ describe("receive_message", () => {
     );
 
     let remainingAccountsModified = remainingAccounts.map((a) => {
-      if (a.pubkey.toBase58() === airlockPDA.toBase58()
-        || a.pubkey.toBase58() === selfCallAirlockPDA.toBase58()) {
+      if (a.pubkey.toBase58() === airlockPDA.toBase58()) {
         return {
           pubkey: a.pubkey,
           isWritable: a.isWritable,
@@ -514,7 +498,6 @@ describe("receive_message", () => {
         payer: payer.publicKey,
         messageReceived: messageReceivedPDA,
         airlock: airlockPDA,
-        airlockSelfCall: selfCallAirlockPDA,
         messageExecutor: messageExecutorPDA,
         postedVaa: publicKey,
         wormholeProgram: CORE_BRIDGE_PID,
@@ -706,7 +689,6 @@ export async function generateExternalProgramInstruction(
 export async function generateUpdateVoteWeightWindowLengthsInstruction(
   stakeConnection: StakeConnection,
   airlockPDA: PublicKey,
-  selfCallAirlockPDA: PublicKey,
   windowLength: BN,
 ): Promise<{ messagePayloadBuffer: Buffer; remainingAccounts: any[] }> {
   const [voteWeightWindowLengthsAccountAddress, _] =
@@ -725,7 +707,6 @@ export async function generateUpdateVoteWeightWindowLengthsInstruction(
     .accounts({
       payer: stakeConnection.userPublicKey(),
       airlock: airlockPDA,
-      airlockSelfCall: selfCallAirlockPDA,
       voteWeightWindowLengths: voteWeightWindowLengthsAccountAddress,
       systemProgram: SystemProgram.programId,
     })


### PR DESCRIPTION
As discussed this is unnecessary because reentrancy is not possible in Solana. Getting rid of this account will reduce costs.