### PR TITLE
[solana] Ensure window length cannot exceed checkpoint account limit

### DIFF
--- a/solana/programs/staking/Cargo.toml
+++ b/solana/programs/staking/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "lib"]
 name = "staking"
 
 [features]
+testing = []
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
@@ -17,7 +18,7 @@ wasm = ["no-entrypoint", "js-sys", "bincode"]
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build", "wormhole-anchor-sdk/idl-build"]
 default = ["testnet", "idl-build"]
 localnet = ["wormhole-solana-consts/localnet"]
-testnet = ["wormhole-solana-consts/testnet", "wormhole-anchor-sdk/solana-devnet"]
+testnet = ["testing", "wormhole-solana-consts/testnet", "wormhole-anchor-sdk/solana-devnet"]
 mainnet = ["wormhole-solana-consts/mainnet", "wormhole-anchor-sdk/mainnet"]
 
 [dependencies]

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -99,6 +99,12 @@ pub mod staking {
         // The checkpoint account contains 8 + 32 + 8 = 48 bytes of fixed data
         // Every checkpoint is 8 + 8 = 16 bytes, so we can fit in (10485760 - 48) / 16 = 655,357 checkpoints
         require!(args.max_checkpoints_account_limit <= 655_000, ErrorCode::InvalidCheckpointAccountLimit);
+        // Similarly make sure max_checkpoints_account_limit > MAX_VOTE_WEIGHT_WINDOW_LENGTH so we can't have
+        // 3 checkpoint accounts fall across a window. We don't mind for our tests
+        #[cfg(not(feature = "testing"))]
+        {
+            require!(args.max_checkpoints_account_limit > state::vote_weight_window_lengths::VoteWeightWindowLengths::MAX_VOTE_WEIGHT_WINDOW_LENGTH as u32, ErrorCode::InvalidCheckpointAccountLimit);
+        }
         config_account.max_checkpoints_account_limit = args.max_checkpoints_account_limit;
         config_account.pending_governance_authority = None;
         config_account.pending_vesting_admin = None;


### PR DESCRIPTION
Is there a better way to do this?

Adding this constraint breaks a bunch of tests and enforcing it in tests would make the tests extremely expensive (from a time point of view as we need to fill up checkpoint accounts for some tests), hence the conditional compilation