### PR TITLE
[solana] Emit `new_weight` instead of `total_weight` in `lib.rs__cast_vote()`

### DIFF
--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -674,7 +674,7 @@ pub mod staking {
             emit!(VoteCast {
                 voter: ctx.accounts.owner.key(),
                 proposal_id,
-                weight: total_weight,
+                weight: new_weight,
                 against_votes,
                 for_votes,
                 abstain_votes
@@ -683,7 +683,7 @@ pub mod staking {
             emit_cpi!(VoteCast {
                 voter: ctx.accounts.owner.key(),
                 proposal_id,
-                weight: total_weight,
+                weight: new_weight,
                 against_votes,
                 for_votes,
                 abstain_votes


### PR DESCRIPTION
Currently `cast_vote()` emits `total_weight` as the weight parameter so this PR fixes it using `new_weight`