### PR TITLE
[solana] Deactivate feature for testing to detect stack frame issues

### DIFF
--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -33,6 +33,9 @@ ledger_dir = "./.anchor/test-ledger"
 idl_path = "./target/idl/staking.json"
 binary_path = "./target/deploy/staking.so"
 
+[test.validator]
+deactivate_feature = ["EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33"]
+
 ### Wormhole Core Bridge Guardian Set 0 (devnet)
 [guardian_set_0]
 address = "dxZtypiKT5D9LYzdPxjvSZER9MgYfeRVU5qpMTMTRs4"

--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -34,7 +34,7 @@ idl_path = "./target/idl/staking.json"
 binary_path = "./target/deploy/staking.so"
 
 [test.validator]
-deactivate_feature = ["EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33"]
+deactivate_feature = ["GJVDwRkUPNdk9QaK4VsU4g1N41QNxhy1hevjf8kz45Mq", "EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33"]
 
 ### Wormhole Core Bridge Guardian Set 0 (devnet)
 [guardian_set_0]


### PR DESCRIPTION
This feature is not enabled on devnet/mainnet. Thus, we deactivate it to ensure stack and heap limits are as expected.