### PR TITLE
[solana] Update vest constraints and seeds

### DIFF
--- a/solana/app/deploy/devnet/tests/11_createStakeAccount.ts
+++ b/solana/app/deploy/devnet/tests/11_createStakeAccount.ts
@@ -3,15 +3,15 @@
 import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
 import { Connection } from "@solana/web3.js";
 import { StakeConnection } from "../../../StakeConnection";
-import { USER_AUTHORITY_KEYPAIR, USER2_AUTHORITY_KEYPAIR, RPC_NODE } from "../constants";
+import {
+  USER_AUTHORITY_KEYPAIR,
+  USER2_AUTHORITY_KEYPAIR,
+  RPC_NODE,
+} from "../constants";
 
 async function createStakeAccount(userKeypair: anchor.web3.Keypair) {
   const connection = new Connection(RPC_NODE);
-  const provider = new AnchorProvider(
-    connection,
-    new Wallet(userKeypair),
-    {},
-  );
+  const provider = new AnchorProvider(connection, new Wallet(userKeypair), {});
 
   const stakeConnection = await StakeConnection.createStakeConnection(
     connection,
@@ -20,7 +20,9 @@ async function createStakeAccount(userKeypair: anchor.web3.Keypair) {
 
   const tx = await stakeConnection.createStakeAccount();
 
-  console.log(`Stake account created successfully for user: ${provider.wallet.publicKey.toBase58()}`);
+  console.log(
+    `Stake account created successfully for user: ${provider.wallet.publicKey.toBase58()}`,
+  );
   console.log("Transaction signature:", tx);
 }
 

--- a/solana/app/deploy/devnet/tests/12_deposit.ts
+++ b/solana/app/deploy/devnet/tests/12_deposit.ts
@@ -18,11 +18,7 @@ import {
 
 async function performDeposit(userKeypair: anchor.web3.Keypair) {
   const connection = new Connection(RPC_NODE);
-  const provider = new AnchorProvider(
-    connection,
-    new Wallet(userKeypair),
-    {},
-  );
+  const provider = new AnchorProvider(connection, new Wallet(userKeypair), {});
   const user = provider.wallet.publicKey;
   const idl = (await Program.fetchIdl(STAKING_ADDRESS, provider))!;
   const program = new Program(idl, provider);
@@ -54,7 +50,9 @@ async function performDeposit(userKeypair: anchor.web3.Keypair) {
     skipPreflight: false,
   });
 
-  console.log(`Deposit transaction completed successfully for user: ${user.toBase58()}`);
+  console.log(
+    `Deposit transaction completed successfully for user: ${user.toBase58()}`,
+  );
   console.log("Transaction signature:", tx);
 }
 

--- a/solana/app/deploy/devnet/tests/14_delegate.ts
+++ b/solana/app/deploy/devnet/tests/14_delegate.ts
@@ -20,11 +20,7 @@ async function delegateStake(
   delegateTo?: PublicKey,
 ) {
   const connection = new Connection(RPC_NODE);
-  const provider = new AnchorProvider(
-    connection,
-    new Wallet(userKeypair),
-    {},
-  );
+  const provider = new AnchorProvider(connection, new Wallet(userKeypair), {});
 
   const stakeConnection = await StakeConnection.createStakeConnection(
     connection,
@@ -34,7 +30,9 @@ async function delegateStake(
   await sleep(2000);
   await stakeConnection.delegate(delegateTo, WHTokenBalance.fromString(amount));
 
-  console.log(`Delegation successful for user: ${provider.wallet.publicKey.toBase58()}`);
+  console.log(
+    `Delegation successful for user: ${provider.wallet.publicKey.toBase58()}`,
+  );
   if (delegateTo) {
     console.log(`Delegated to: ${delegateTo.toBase58()}`);
   }
@@ -47,7 +45,11 @@ async function main() {
     // Second user delegates to himself
     await delegateStake(USER2_AUTHORITY_KEYPAIR, "10000000");
     // First user delegates to second user
-    await delegateStake(USER_AUTHORITY_KEYPAIR, "10000000", USER2_AUTHORITY_KEYPAIR.publicKey);
+    await delegateStake(
+      USER_AUTHORITY_KEYPAIR,
+      "10000000",
+      USER2_AUTHORITY_KEYPAIR.publicKey,
+    );
   } catch (err) {
     console.error("Error:", err);
   }

--- a/solana/app/deploy/devnet/tests/getProgramIdBytes32Hex.ts
+++ b/solana/app/deploy/devnet/tests/getProgramIdBytes32Hex.ts
@@ -8,7 +8,10 @@ async function main() {
   try {
     const programId = await input({ message: "Enter the program id:" });
     const programIdPublicKey = new PublicKey(programId);
-    console.log('Program ID:', "0x" + Buffer.from(programIdPublicKey.toBytes()).toString('hex'))
+    console.log(
+      "Program ID:",
+      "0x" + Buffer.from(programIdPublicKey.toBytes()).toString("hex"),
+    );
   } catch (err) {
     console.error("Error:", err);
   }

--- a/solana/app/deploy/devnet/update/claimVestingAdmin.ts
+++ b/solana/app/deploy/devnet/update/claimVestingAdmin.ts
@@ -2,10 +2,7 @@
 
 import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
 import { Connection } from "@solana/web3.js";
-import {
-  RPC_NODE,
-  NEW_VESTING_ADMIN_KEYPAIR,
-} from "../constants";
+import { RPC_NODE, NEW_VESTING_ADMIN_KEYPAIR } from "../constants";
 import { Staking } from "../../../../target/types/staking";
 import fs from "fs";
 

--- a/solana/app/deploy/devnet/update/updateVestingAdmin.ts
+++ b/solana/app/deploy/devnet/update/updateVestingAdmin.ts
@@ -2,10 +2,7 @@
 
 import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
 import { Connection, PublicKey } from "@solana/web3.js";
-import {
-  VESTING_ADMIN_KEYPAIR,
-  RPC_NODE,
-} from "../constants";
+import { VESTING_ADMIN_KEYPAIR, RPC_NODE } from "../constants";
 import { Staking } from "../../../../target/types/staking";
 import fs from "fs";
 

--- a/solana/app/deploy/devnet/vesting/createVestingConfig.ts
+++ b/solana/app/deploy/devnet/vesting/createVestingConfig.ts
@@ -116,7 +116,6 @@ async function main() {
     config,
     vault,
     vester: vester.publicKey,
-    vesterTa,
     adminAta,
     recovery: adminAta,
     associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -137,7 +136,7 @@ async function main() {
 
   console.log("Creating vesting balance for vester...");
   await stakeConnection.program.methods
-    .createVestingBalance()
+    .createVestingBalance(vester.publicKey)
     .accounts({ ...accounts })
     .signers([admin])
     .rpc()
@@ -147,7 +146,7 @@ async function main() {
 
   console.log(`Creating vest for vester at NOW (${NOW.toString()})...`);
   await stakeConnection.program.methods
-    .createVesting(NOW, new BN(20e6))
+    .createVesting(vester.publicKey, NOW, new BN(20e6))
     .accounts({ ...accounts })
     .signers([admin])
     .rpc()
@@ -157,7 +156,7 @@ async function main() {
 
   console.log(`Creating vest for vester at LATER (${LATER.toString()})...`);
   await stakeConnection.program.methods
-    .createVesting(LATER, new BN(20e6))
+    .createVesting(vester.publicKey, LATER, new BN(20e6))
     .accounts({ ...accounts })
     .signers([admin])
     .rpc()
@@ -169,7 +168,7 @@ async function main() {
     `Creating vest for vester at EVEN_LATER (${EVEN_LATER.toString()})...`,
   );
   await stakeConnection.program.methods
-    .createVesting(EVEN_LATER, new BN(20e6))
+    .createVesting(vester.publicKey, EVEN_LATER, new BN(20e6))
     .accounts({ ...accounts })
     .signers([admin])
     .rpc()
@@ -191,7 +190,7 @@ async function main() {
 
   console.log(`Canceling vest for vester at LATER (${LATER.toString()})...`);
   await stakeConnection.program.methods
-    .cancelVesting()
+    .cancelVesting(vester.publicKey)
     .accountsPartial({ ...accounts, vest: vestLater })
     .signers([admin])
     .rpc()

--- a/solana/app/deploy/devnet/vesting/transferVesting.ts
+++ b/solana/app/deploy/devnet/vesting/transferVesting.ts
@@ -156,8 +156,6 @@ async function main() {
   let accounts = {
     vester: vester.publicKey,
     mint: WORMHOLE_TOKEN,
-    vesterTa,
-    newVesterTa,
     config,
     vest: vestEvenLater,
     newVest: newVestEvenLater,
@@ -194,7 +192,7 @@ async function main() {
       })
       .instruction(),
     await vesterStakeConnection.program.methods
-      .transferVesting()
+      .transferVesting(newVester.publicKey)
       .accountsPartial({ ...accounts })
       .instruction(),
     await vesterStakeConnection.program.methods
@@ -229,7 +227,7 @@ async function main() {
   //
   //   console.log("Starting transferVesting...");
   //     await vesterStakeConnection.program.methods
-  //       .transferVesting()
+  //       .transferVesting(newVester.publicKey)
   //       .accountsPartial({
   //         ...accounts
   //       })

--- a/solana/app/e2e/external_program/idl/external_program.ts
+++ b/solana/app/e2e/external_program/idl/external_program.ts
@@ -5,273 +5,188 @@
  * IDL can be found at `target/idl/external_program.json`.
  */
 export type ExternalProgram = {
-  "address": "eLUV8cwhgUC2Bcu4UA16uhuMwK8zPkx3XSzt4hd3JJ3",
-  "metadata": {
-    "name": "externalProgram",
-    "version": "0.1.0",
-    "spec": "0.1.0"
-  },
-  "instructions": [
+  address: "eLUV8cwhgUC2Bcu4UA16uhuMwK8zPkx3XSzt4hd3JJ3";
+  metadata: {
+    name: "externalProgram";
+    version: "0.1.0";
+    spec: "0.1.0";
+  };
+  instructions: [
     {
-      "name": "adminAction",
-      "discriminator": [
-        37,
-        85,
-        83,
-        175,
-        64,
-        105,
-        224,
-        66
-      ],
-      "accounts": [
+      name: "adminAction";
+      discriminator: [37, 85, 83, 175, 64, 105, 224, 66];
+      accounts: [
         {
-          "name": "admin",
-          "docs": [
-            "CHECK"
-          ],
-          "writable": true,
-          "relations": [
-            "config"
-          ]
+          name: "admin";
+          docs: ["CHECK"];
+          writable: true;
+          relations: ["config"];
         },
         {
-          "name": "config",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "config";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103,
-                  86,
-                  50
-                ]
-              }
-            ]
-          }
+                kind: "const";
+                value: [99, 111, 110, 102, 105, 103, 86, 50];
+              },
+            ];
+          };
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": []
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        },
+      ];
+      args: [];
     },
     {
-      "name": "initialize",
-      "discriminator": [
-        175,
-        175,
-        109,
-        31,
-        13,
-        152,
-        155,
-        237
-      ],
-      "accounts": [
+      name: "initialize";
+      discriminator: [175, 175, 109, 31, 13, 152, 155, 237];
+      accounts: [
         {
-          "name": "payer",
-          "writable": true,
-          "signer": true
+          name: "payer";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "config",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "config";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103,
-                  86,
-                  50
-                ]
-              }
-            ]
-          }
+                kind: "const";
+                value: [99, 111, 110, 102, 105, 103, 86, 50];
+              },
+            ];
+          };
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        },
+      ];
+      args: [
         {
-          "name": "superAdmin",
-          "type": "pubkey"
+          name: "superAdmin";
+          type: "pubkey";
         },
         {
-          "name": "admin",
-          "type": "pubkey"
-        }
-      ]
+          name: "admin";
+          type: "pubkey";
+        },
+      ];
     },
     {
-      "name": "updateAdmin",
-      "discriminator": [
-        161,
-        176,
-        40,
-        213,
-        60,
-        184,
-        179,
-        228
-      ],
-      "accounts": [
+      name: "updateAdmin";
+      discriminator: [161, 176, 40, 213, 60, 184, 179, 228];
+      accounts: [
         {
-          "name": "superAdmin",
-          "writable": true,
-          "signer": true
+          name: "superAdmin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "config",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "config";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  110,
-                  102,
-                  105,
-                  103,
-                  86,
-                  50
-                ]
-              }
-            ]
-          }
+                kind: "const";
+                value: [99, 111, 110, 102, 105, 103, 86, 50];
+              },
+            ];
+          };
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        },
+      ];
+      args: [
         {
-          "name": "newAdmin",
-          "type": "pubkey"
-        }
-      ]
-    }
-  ],
-  "accounts": [
+          name: "newAdmin";
+          type: "pubkey";
+        },
+      ];
+    },
+  ];
+  accounts: [
     {
-      "name": "config",
-      "discriminator": [
-        155,
-        12,
-        170,
-        224,
-        30,
-        250,
-        204,
-        130
-      ]
-    }
-  ],
-  "events": [
+      name: "config";
+      discriminator: [155, 12, 170, 224, 30, 250, 204, 130];
+    },
+  ];
+  events: [
     {
-      "name": "adminActionEvent",
-      "discriminator": [
-        220,
-        224,
-        207,
-        200,
-        52,
-        226,
-        42,
-        155
-      ]
+      name: "adminActionEvent";
+      discriminator: [220, 224, 207, 200, 52, 226, 42, 155];
     },
     {
-      "name": "updateAdminEvent",
-      "discriminator": [
-        225,
-        152,
-        171,
-        87,
-        246,
-        63,
-        66,
-        234
-      ]
-    }
-  ],
-  "errors": [
+      name: "updateAdminEvent";
+      discriminator: [225, 152, 171, 87, 246, 63, 66, 234];
+    },
+  ];
+  errors: [
     {
-      "code": 6000,
-      "name": "unauthorized",
-      "msg": "Unauthorized: Only the admin can perform this action."
-    }
-  ],
-  "types": [
+      code: 6000;
+      name: "unauthorized";
+      msg: "Unauthorized: Only the admin can perform this action.";
+    },
+  ];
+  types: [
     {
-      "name": "adminActionEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "adminActionEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "admin",
-            "type": "pubkey"
+            name: "admin";
+            type: "pubkey";
           },
           {
-            "name": "count",
-            "type": "u64"
-          }
-        ]
-      }
+            name: "count";
+            type: "u64";
+          },
+        ];
+      };
     },
     {
-      "name": "config",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "config";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "superAdmin",
-            "type": "pubkey"
+            name: "superAdmin";
+            type: "pubkey";
           },
           {
-            "name": "admin",
-            "type": "pubkey"
+            name: "admin";
+            type: "pubkey";
           },
           {
-            "name": "counter",
-            "type": "u64"
-          }
-        ]
-      }
+            name: "counter";
+            type: "u64";
+          },
+        ];
+      };
     },
     {
-      "name": "updateAdminEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "updateAdminEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "previousAdmin",
-            "type": "pubkey"
+            name: "previousAdmin";
+            type: "pubkey";
           },
           {
-            "name": "newAdmin",
-            "type": "pubkey"
-          }
-        ]
-      }
-    }
-  ]
+            name: "newAdmin";
+            type: "pubkey";
+          },
+        ];
+      };
+    },
+  ];
 };

--- a/solana/programs/staking/src/contexts/cancel_vesting.rs
+++ b/solana/programs/staking/src/contexts/cancel_vesting.rs
@@ -32,9 +32,9 @@ pub struct CancelVesting<'info> {
     #[account(
         mut,
         close = admin,
-        has_one = vester_ta,
+        constraint = vest.vester == vester_ta.owner @ VestingError::InvalidVester,
         has_one = config, // This check is arbitrary, as ATA is baked into the PDA
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vest.vester_ta.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump = vest.bump
     )]
     vest: Account<'info, Vesting>,

--- a/solana/programs/staking/src/contexts/cancel_vesting.rs
+++ b/solana/programs/staking/src/contexts/cancel_vesting.rs
@@ -3,7 +3,6 @@ use crate::error::VestingError;
 use crate::state::global_config::GlobalConfig;
 use crate::state::{Vesting, VestingBalance, VestingConfig};
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 #[derive(Accounts)]
@@ -16,9 +15,9 @@ pub struct CancelVesting<'info> {
     admin: Signer<'info>,
     mint: Account<'info, Mint>,
     #[account(
-        associated_token::mint = mint,
-        associated_token::authority = vester_ta.owner,
-        associated_token::token_program = token_program
+        token::mint = mint,
+        token::authority = vester_ta.owner,
+        token::token_program = token_program
     )]
     vester_ta: Account<'info, TokenAccount>,
     #[account(
@@ -49,7 +48,6 @@ pub struct CancelVesting<'info> {
         bump = global_config.bump,
     )]
     pub global_config: Box<Account<'info, GlobalConfig>>,
-    associated_token_program: Program<'info, AssociatedToken>,
     token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }

--- a/solana/programs/staking/src/contexts/claim_vesting.rs
+++ b/solana/programs/staking/src/contexts/claim_vesting.rs
@@ -26,9 +26,9 @@ pub struct ClaimVesting<'info> {
     vault: Account<'info, TokenAccount>,
     #[account(
         mut,
-        associated_token::mint = mint,
-        associated_token::authority = vester,
-        associated_token::token_program = token_program
+        token::mint = mint,
+        token::authority = vester,
+        token::token_program = token_program
     )]
     vester_ta: Account<'info, TokenAccount>,
     #[account(

--- a/solana/programs/staking/src/contexts/claim_vesting.rs
+++ b/solana/programs/staking/src/contexts/claim_vesting.rs
@@ -42,9 +42,9 @@ pub struct ClaimVesting<'info> {
         mut,
         close = admin,
         constraint = Clock::get()?.unix_timestamp >= vest.maturation @ VestingError::NotFullyVested,
-        has_one = vester_ta, // This check is arbitrary, as ATA is baked into the PDA
+        constraint = vest.vester == vester_ta.owner @ VestingError::InvalidVester,
         has_one = config, // This check is arbitrary, as ATA is baked into the PDA
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump = vest.bump
     )]
     vest: Account<'info, Vesting>,

--- a/solana/programs/staking/src/contexts/create_vesting.rs
+++ b/solana/programs/staking/src/contexts/create_vesting.rs
@@ -3,11 +3,10 @@ use crate::error::VestingError;
 use crate::state::global_config::GlobalConfig;
 use crate::state::{Vesting, VestingBalance, VestingConfig};
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{Mint, Token, TokenAccount};
+use anchor_spl::token::{Mint, Token};
 
 #[derive(Accounts)]
-#[instruction(maturation: i64)]
+#[instruction(vester: Pubkey, maturation: i64, _amount: u64)]
 pub struct CreateVesting<'info> {
     #[account(
         mut,
@@ -16,12 +15,6 @@ pub struct CreateVesting<'info> {
     )]
     admin: Signer<'info>,
     mint: Account<'info, Mint>,
-    #[account(
-        associated_token::mint = mint,
-        associated_token::authority = vester_ta.owner,
-        associated_token::token_program = token_program
-    )]
-    vester_ta: Account<'info, TokenAccount>,
     #[account(
         mut,
         constraint = !config.finalized @ VestingError::VestingFinalized, // A vest can only be created before a vest is finalized
@@ -34,13 +27,13 @@ pub struct CreateVesting<'info> {
         init,
         payer = admin,
         space = Vesting::LEN,
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester.as_ref(), maturation.to_le_bytes().as_ref()],
         bump
     )]
     vest: Account<'info, Vesting>,
     #[account(
         mut,
-        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref()],
+        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester.as_ref()],
         bump = vesting_balance.bump
     )]
     vesting_balance: Account<'info, VestingBalance>,
@@ -49,13 +42,12 @@ pub struct CreateVesting<'info> {
         bump = global_config.bump,
     )]
     pub global_config: Box<Account<'info, GlobalConfig>>,
-    associated_token_program: Program<'info, AssociatedToken>,
     token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }
 
 impl<'info> CreateVesting<'info> {
-    pub fn create_vesting(&mut self, maturation: i64, amount: u64, bump: u8) -> Result<()> {
+    pub fn create_vesting(&mut self, vester: Pubkey, maturation: i64, amount: u64, bump: u8) -> Result<()> {
         // Add to total vested amount
         self.config.vested = self
             .config
@@ -70,7 +62,7 @@ impl<'info> CreateVesting<'info> {
             .ok_or(VestingError::Overflow)?;
 
         self.vest.set_inner(Vesting {
-            vester: self.vester_ta.owner.key(),
+            vester,
             config: self.config.key(),
             amount,
             maturation,

--- a/solana/programs/staking/src/contexts/create_vesting.rs
+++ b/solana/programs/staking/src/contexts/create_vesting.rs
@@ -34,7 +34,7 @@ pub struct CreateVesting<'info> {
         init,
         payer = admin,
         space = Vesting::LEN,
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.key().as_ref(), maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), maturation.to_le_bytes().as_ref()],
         bump
     )]
     vest: Account<'info, Vesting>,
@@ -70,7 +70,7 @@ impl<'info> CreateVesting<'info> {
             .ok_or(VestingError::Overflow)?;
 
         self.vest.set_inner(Vesting {
-            vester_ta: self.vester_ta.key(),
+            vester: self.vester_ta.owner.key(),
             config: self.config.key(),
             amount,
             maturation,

--- a/solana/programs/staking/src/contexts/create_vesting.rs
+++ b/solana/programs/staking/src/contexts/create_vesting.rs
@@ -47,7 +47,13 @@ pub struct CreateVesting<'info> {
 }
 
 impl<'info> CreateVesting<'info> {
-    pub fn create_vesting(&mut self, vester: Pubkey, maturation: i64, amount: u64, bump: u8) -> Result<()> {
+    pub fn create_vesting(
+        &mut self,
+        vester: Pubkey,
+        maturation: i64,
+        amount: u64,
+        bump: u8,
+    ) -> Result<()> {
         // Add to total vested amount
         self.config.vested = self
             .config

--- a/solana/programs/staking/src/contexts/create_vesting_balance.rs
+++ b/solana/programs/staking/src/contexts/create_vesting_balance.rs
@@ -3,11 +3,10 @@ use crate::error::VestingError;
 use crate::state::global_config::GlobalConfig;
 use crate::state::{VestingBalance, VestingConfig};
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{Mint, Token, TokenAccount};
+use anchor_spl::token::{Mint, Token};
 
 #[derive(Accounts)]
-#[instruction()]
+#[instruction(vester: Pubkey)]
 pub struct CreateVestingBalance<'info> {
     #[account(
         mut,
@@ -26,30 +25,23 @@ pub struct CreateVestingBalance<'info> {
         init,
         payer = admin,
         space = VestingBalance::LEN,
-        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref()],
+        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester.as_ref()],
         bump
     )]
     vesting_balance: Account<'info, VestingBalance>,
-    #[account(
-        associated_token::mint = mint,
-        associated_token::authority = vester_ta.owner,
-        associated_token::token_program = token_program
-    )]
-    vester_ta: Account<'info, TokenAccount>,
     #[account(
         seeds = [CONFIG_SEED.as_bytes()],
         bump = global_config.bump,
     )]
     pub global_config: Box<Account<'info, GlobalConfig>>,
-    associated_token_program: Program<'info, AssociatedToken>,
     token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }
 
 impl<'info> CreateVestingBalance<'info> {
-    pub fn create_vesting_balance(&mut self, bump: u8) -> Result<()> {
+    pub fn create_vesting_balance(&mut self, vester: Pubkey, bump: u8) -> Result<()> {
         self.vesting_balance.set_inner(VestingBalance {
-            vester: self.vester_ta.owner.key(),
+            vester,
             stake_account_metadata: Pubkey::default(),
             total_vesting_balance: 0,
             bump,

--- a/solana/programs/staking/src/contexts/transfer_vesting.rs
+++ b/solana/programs/staking/src/contexts/transfer_vesting.rs
@@ -42,9 +42,9 @@ pub struct TransferVesting<'info> {
     #[account(
         mut,
         close = vester,
-        has_one = vester_ta, // This check is arbitrary, as ATA is baked into the PDA
+        constraint = vest.vester == vester_ta.owner @ VestingError::InvalidVester,
         has_one = config, // This check is arbitrary, as ATA is baked into the PDA
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump = vest.bump
     )]
     vest: Box<Account<'info, Vesting>>,
@@ -52,7 +52,7 @@ pub struct TransferVesting<'info> {
         init_if_needed,
         payer = vester,
         space = Vesting::LEN,
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), new_vester_ta.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), new_vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump
     )]
     new_vest: Box<Account<'info, Vesting>>,
@@ -321,7 +321,7 @@ impl<'info> crate::contexts::TransferVesting<'info> {
         }
 
         self.new_vest.set_inner(Vesting {
-            vester_ta: self.new_vester_ta.key(),
+            vester: self.new_vester_ta.owner.key(),
             config: self.vest.config,
             amount: self
                 .new_vest

--- a/solana/programs/staking/src/contexts/transfer_vesting.rs
+++ b/solana/programs/staking/src/contexts/transfer_vesting.rs
@@ -272,7 +272,10 @@ impl<'info> crate::contexts::TransferVesting<'info> {
             );
 
             let (expected_stake_account_metadata_pda, _) = Pubkey::find_program_address(
-                &[STAKE_ACCOUNT_METADATA_SEED.as_bytes(), self.vester.key().as_ref()],
+                &[
+                    STAKE_ACCOUNT_METADATA_SEED.as_bytes(),
+                    self.vester.key().as_ref(),
+                ],
                 &crate::ID,
             );
             require!(

--- a/solana/programs/staking/src/contexts/transfer_vesting.rs
+++ b/solana/programs/staking/src/contexts/transfer_vesting.rs
@@ -8,30 +8,15 @@ use crate::state::stake_account::{RecordedVestingBalanceChanged, StakeAccountMet
 use crate::state::{Vesting, VestingBalance, VestingConfig};
 use crate::{error::ErrorCode, error::VestingError};
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{Mint, Token, TokenAccount};
-use spl_token::state::AccountState;
+use anchor_spl::token::{Mint, Token};
 
 #[event_cpi]
 #[derive(Accounts)]
+#[instruction(new_vester: Pubkey)]
 pub struct TransferVesting<'info> {
     #[account(mut)]
     vester: Signer<'info>,
     mint: Box<Account<'info, Mint>>,
-    #[account(
-        mut,
-        associated_token::mint = mint,
-        associated_token::authority = vester_ta.owner,
-        associated_token::token_program = token_program
-    )]
-    vester_ta: Box<Account<'info, TokenAccount>>,
-    #[account(
-        mut,
-        associated_token::mint = mint,
-        associated_token::authority = new_vester_ta.owner,
-        associated_token::token_program = token_program
-    )]
-    new_vester_ta: Box<Account<'info, TokenAccount>>,
     #[account(
         mut,
         constraint = config.finalized @ VestingError::VestingUnfinalized,
@@ -42,9 +27,9 @@ pub struct TransferVesting<'info> {
     #[account(
         mut,
         close = vester,
-        constraint = vest.vester == vester_ta.owner @ VestingError::InvalidVester,
-        has_one = config, // This check is arbitrary, as ATA is baked into the PDA
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        constraint = vest.vester == vester.key() @ VestingError::InvalidVester,
+        has_one = config, // This check is arbitrary, as config is baked into the PDA
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), vester.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump = vest.bump
     )]
     vest: Box<Account<'info, Vesting>>,
@@ -52,14 +37,14 @@ pub struct TransferVesting<'info> {
         init_if_needed,
         payer = vester,
         space = Vesting::LEN,
-        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), new_vester_ta.owner.key().as_ref(), vest.maturation.to_le_bytes().as_ref()],
+        seeds = [VEST_SEED.as_bytes(), config.key().as_ref(), new_vester.as_ref(), vest.maturation.to_le_bytes().as_ref()],
         bump
     )]
     new_vest: Box<Account<'info, Vesting>>,
     #[account(
         mut,
-        has_one = vester,
-        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester_ta.owner.key().as_ref()],
+        has_one = vester, // This check is arbitrary, as vester is baked into the PDA
+        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), vester.key().as_ref()],
         bump = vesting_balance.bump
     )]
     vesting_balance: Box<Account<'info, VestingBalance>>,
@@ -67,7 +52,7 @@ pub struct TransferVesting<'info> {
         init_if_needed,
         payer = vester,
         space = VestingBalance::LEN,
-        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), new_vester_ta.owner.key().as_ref()],
+        seeds = [VESTING_BALANCE_SEED.as_bytes(), config.key().as_ref(), new_vester.as_ref()],
         bump
     )]
     new_vesting_balance: Box<Account<'info, VestingBalance>>,
@@ -88,7 +73,6 @@ pub struct TransferVesting<'info> {
     #[account(mut)]
     pub new_stake_account_metadata: Option<Box<Account<'info, StakeAccountMetadata>>>,
 
-    associated_token_program: Program<'info, AssociatedToken>,
     token_program: Program<'info, Token>,
     system_program: Program<'info, System>,
 }
@@ -108,6 +92,7 @@ pub struct TransferVestingEvents {
 impl<'info> crate::contexts::TransferVesting<'info> {
     pub fn transfer_vesting(
         &mut self,
+        new_vester: Pubkey,
         new_vest_bump: u8,
         new_vesting_balance_bump: u8,
     ) -> Result<TransferVestingEvents> {
@@ -116,13 +101,8 @@ impl<'info> crate::contexts::TransferVesting<'info> {
             new_stake_account_metadata: None,
         };
 
-        // Check if vester_ta is frozen
-        if self.vester_ta.state == AccountState::Frozen {
-            return err!(VestingError::FrozenVesterAccount);
-        }
-
         // Self transfers are not allowed
-        if self.new_vester_ta.owner.key() == self.vester_ta.owner.key() {
+        if new_vester == self.vester.key() {
             return err!(VestingError::TransferVestToMyself);
         }
 
@@ -166,15 +146,12 @@ impl<'info> crate::contexts::TransferVesting<'info> {
 
                 // Additional checks to ensure the owner matches
                 require!(
-                    new_stake_account_metadata.owner == self.new_vesting_balance.vester,
+                    new_stake_account_metadata.owner == new_vester,
                     VestingError::InvalidStakeAccountOwner
                 );
 
                 let (expected_stake_account_metadata_vester_pda, _) = Pubkey::find_program_address(
-                    &[
-                        STAKE_ACCOUNT_METADATA_SEED.as_bytes(),
-                        self.new_vester_ta.owner.key().as_ref(),
-                    ],
+                    &[STAKE_ACCOUNT_METADATA_SEED.as_bytes(), new_vester.as_ref()],
                     &crate::ID,
                 );
                 require!(
@@ -295,10 +272,7 @@ impl<'info> crate::contexts::TransferVesting<'info> {
             );
 
             let (expected_stake_account_metadata_pda, _) = Pubkey::find_program_address(
-                &[
-                    STAKE_ACCOUNT_METADATA_SEED.as_bytes(),
-                    self.vester.key().as_ref(),
-                ],
+                &[STAKE_ACCOUNT_METADATA_SEED.as_bytes(), self.vester.key().as_ref()],
                 &crate::ID,
             );
             require!(
@@ -321,7 +295,7 @@ impl<'info> crate::contexts::TransferVesting<'info> {
         }
 
         self.new_vest.set_inner(Vesting {
-            vester: self.new_vester_ta.owner.key(),
+            vester: new_vester,
             config: self.vest.config,
             amount: self
                 .new_vest
@@ -333,7 +307,7 @@ impl<'info> crate::contexts::TransferVesting<'info> {
         });
 
         self.new_vesting_balance.set_inner(VestingBalance {
-            vester: self.new_vester_ta.owner.key(),
+            vester: new_vester,
             stake_account_metadata: self.new_vesting_balance.stake_account_metadata,
             total_vesting_balance: self
                 .new_vesting_balance

--- a/solana/programs/staking/src/error.rs
+++ b/solana/programs/staking/src/error.rs
@@ -107,6 +107,8 @@ pub enum VestingError {
     StakeAccountDelegationLoop,
     #[msg("Cannot transfer vesting from a frozen token account")]
     FrozenVesterAccount,
+    #[msg("The token account owner does not match the vesting account")]
+    InvalidVester,
 }
 
 #[error_code]

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -726,9 +726,13 @@ pub mod staking {
     }
 
     // Open a new Vesting account and deposit equivalent vested tokens to vault
-    pub fn create_vesting(ctx: Context<CreateVesting>, maturation: i64, amount: u64) -> Result<()> {
-        ctx.accounts
-            .create_vesting(maturation, amount, ctx.bumps.vest)
+    pub fn create_vesting(
+        ctx: Context<CreateVesting>,
+        vester: Pubkey,
+        maturation: i64,
+        amount: u64
+    ) -> Result<()> {
+        ctx.accounts.create_vesting(vester, maturation, amount, ctx.bumps.vest)
     }
 
     // Claim from and close a Vesting account

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -753,11 +753,14 @@ pub mod staking {
         Ok(())
     }
 
-    // Transfer Vesting from and send to new Vester
-    pub fn transfer_vesting(ctx: Context<TransferVesting>) -> Result<()> {
+    // Transfer vesting to a new vester
+    pub fn transfer_vesting(
+        ctx: Context<TransferVesting>,
+        new_vester: Pubkey
+    ) -> Result<()> {
         let transfer_vesting_events = ctx
             .accounts
-            .transfer_vesting(ctx.bumps.new_vest, ctx.bumps.new_vesting_balance)?;
+            .transfer_vesting(new_vester, ctx.bumps.new_vest, ctx.bumps.new_vesting_balance)?;
 
         if let Some(stake_account_metadata) = transfer_vesting_events.stake_account_metadata {
             emit_cpi!(stake_account_metadata.recorded_vesting_balance_changed);

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -712,17 +712,14 @@ pub mod staking {
     // Create a new vesting balance account
     pub fn create_vesting_balance(
         ctx: Context<CreateVestingBalance>,
-        vester: Pubkey
+        vester: Pubkey,
     ) -> Result<()> {
         ctx.accounts
             .create_vesting_balance(vester, ctx.bumps.vesting_balance)
     }
 
     // Closes a vesting balance account
-    pub fn close_vesting_balance(
-        ctx: Context<CloseVestingBalance>,
-        _vester: Pubkey
-    ) -> Result<()> {
+    pub fn close_vesting_balance(ctx: Context<CloseVestingBalance>, _vester: Pubkey) -> Result<()> {
         ctx.accounts.close_vesting_balance()
     }
 
@@ -736,9 +733,10 @@ pub mod staking {
         ctx: Context<CreateVesting>,
         vester: Pubkey,
         maturation: i64,
-        amount: u64
+        amount: u64,
     ) -> Result<()> {
-        ctx.accounts.create_vesting(vester, maturation, amount, ctx.bumps.vest)
+        ctx.accounts
+            .create_vesting(vester, maturation, amount, ctx.bumps.vest)
     }
 
     // Claim from and close a Vesting account
@@ -754,13 +752,12 @@ pub mod staking {
     }
 
     // Transfer vesting to a new vester
-    pub fn transfer_vesting(
-        ctx: Context<TransferVesting>,
-        new_vester: Pubkey
-    ) -> Result<()> {
-        let transfer_vesting_events = ctx
-            .accounts
-            .transfer_vesting(new_vester, ctx.bumps.new_vest, ctx.bumps.new_vesting_balance)?;
+    pub fn transfer_vesting(ctx: Context<TransferVesting>, new_vester: Pubkey) -> Result<()> {
+        let transfer_vesting_events = ctx.accounts.transfer_vesting(
+            new_vester,
+            ctx.bumps.new_vest,
+            ctx.bumps.new_vesting_balance,
+        )?;
 
         if let Some(stake_account_metadata) = transfer_vesting_events.stake_account_metadata {
             emit_cpi!(stake_account_metadata.recorded_vesting_balance_changed);

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -719,7 +719,10 @@ pub mod staking {
     }
 
     // Closes a vesting balance account
-    pub fn close_vesting_balance(ctx: Context<CloseVestingBalance>) -> Result<()> {
+    pub fn close_vesting_balance(
+        ctx: Context<CloseVestingBalance>,
+        _vester: Pubkey
+    ) -> Result<()> {
         ctx.accounts.close_vesting_balance()
     }
 

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -769,7 +769,7 @@ pub mod staking {
     }
 
     // Cancel and close a Vesting account for a non-finalized Config
-    pub fn cancel_vesting(ctx: Context<CancelVesting>) -> Result<()> {
+    pub fn cancel_vesting(ctx: Context<CancelVesting>, _vester: Pubkey) -> Result<()> {
         ctx.accounts.cancel_vesting()
     }
 

--- a/solana/programs/staking/src/lib.rs
+++ b/solana/programs/staking/src/lib.rs
@@ -709,10 +709,13 @@ pub mod staking {
         ctx.accounts.initialize(seed, ctx.bumps.config)
     }
 
-    // Create a vesting balance account
-    pub fn create_vesting_balance(ctx: Context<CreateVestingBalance>) -> Result<()> {
+    // Create a new vesting balance account
+    pub fn create_vesting_balance(
+        ctx: Context<CreateVestingBalance>,
+        vester: Pubkey
+    ) -> Result<()> {
         ctx.accounts
-            .create_vesting_balance(ctx.bumps.vesting_balance)
+            .create_vesting_balance(vester, ctx.bumps.vesting_balance)
     }
 
     // Closes a vesting balance account

--- a/solana/programs/staking/src/state/vesting.rs
+++ b/solana/programs/staking/src/state/vesting.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 #[account]
 #[derive(Default, InitSpace)]
 pub struct Vesting {
-    pub vester_ta: Pubkey,
+    pub vester: Pubkey,
     pub config: Pubkey,
     pub amount: u64,
     pub maturation: i64,

--- a/solana/tests/cast_vote.ts
+++ b/solana/tests/cast_vote.ts
@@ -165,10 +165,7 @@ describe("castVote", async () => {
   });
 
   it("should fail to castVote if proposal inactive", async () => {
-    await user6StakeConnection.delegate(
-      user6,
-      WHTokenBalance.fromString("50"),
-    );
+    await user6StakeConnection.delegate(user6, WHTokenBalance.fromString("50"));
 
     let proposalIdInput = await addTestProposal(
       user6StakeConnection,
@@ -176,9 +173,7 @@ describe("castVote", async () => {
     );
 
     let stakeAccountMetadataAddress =
-      await user6StakeConnection.getStakeMetadataAddress(
-        user6,
-      );
+      await user6StakeConnection.getStakeMetadataAddress(user6);
     let previousStakeAccountCheckpointsAddress =
       await user6StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         stakeAccountMetadataAddress,
@@ -206,9 +201,7 @@ describe("castVote", async () => {
 
       assert.fail("Expected an error but none was thrown");
     } catch (e) {
-      assert(
-        (e as AnchorError).error?.errorCode?.code === "ProposalInactive",
-      );
+      assert((e as AnchorError).error?.errorCode?.code === "ProposalInactive");
     }
   });
 
@@ -226,9 +219,7 @@ describe("castVote", async () => {
     await sleep(4000);
 
     let stakeAccountMetadataAddress =
-      await user6StakeConnection.getStakeMetadataAddress(
-        user6,
-      );
+      await user6StakeConnection.getStakeMetadataAddress(user6);
     let previousStakeAccountCheckpointsAddress =
       await user6StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         stakeAccountMetadataAddress,
@@ -356,10 +347,7 @@ describe("castVote", async () => {
 
   it("should fail to castVote if next voter checkpoints are invalid", async () => {
     await sleep(1000);
-    await user4StakeConnection.delegate(
-      user4,
-      WHTokenBalance.fromString("5"),
-    );
+    await user4StakeConnection.delegate(user4, WHTokenBalance.fromString("5"));
 
     let voteStart = Math.floor(Date.now() / 1000) + 25;
     let proposalIdInput = await addTestProposal(
@@ -384,10 +372,7 @@ describe("castVote", async () => {
     }
 
     let currentStakeAccountCheckpointsAddress =
-      await user4StakeConnection.getStakeAccountCheckpointsAddress(
-        user4,
-        0,
-      );
+      await user4StakeConnection.getStakeAccountCheckpointsAddress(user4, 0);
     let currentStakeAccountCheckpoints: CheckpointAccount =
       await user4StakeConnection.fetchCheckpointAccount(
         currentStakeAccountCheckpointsAddress,
@@ -398,8 +383,7 @@ describe("castVote", async () => {
       TEST_CHECKPOINTS_ACCOUNT_LIMIT,
     );
     assert(
-      currentStakeAccountCheckpoints.getLastCheckpoint().timestamp <
-        voteStart,
+      currentStakeAccountCheckpoints.getLastCheckpoint().timestamp < voteStart,
     );
 
     try {
@@ -429,10 +413,7 @@ describe("castVote", async () => {
 
   it("should fail to castVote if the wanted checkpoint is the last one in the filled account", async () => {
     let currentStakeAccountCheckpointsAddress =
-      await user4StakeConnection.getStakeAccountCheckpointsAddress(
-        user4,
-        0,
-      );
+      await user4StakeConnection.getStakeAccountCheckpointsAddress(user4, 0);
     let currentStakeAccountCheckpoints: CheckpointAccount =
       await user4StakeConnection.fetchCheckpointAccount(
         currentStakeAccountCheckpointsAddress,
@@ -488,9 +469,7 @@ describe("castVote", async () => {
     }
 
     let user5StakeAccountMetadataAddress =
-      await user5StakeConnection.getStakeMetadataAddress(
-        user5,
-      );
+      await user5StakeConnection.getStakeMetadataAddress(user5);
     let user5StakeAccountCheckpointsAddress =
       await user5StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         user5StakeAccountMetadataAddress,
@@ -559,28 +538,23 @@ describe("castVote", async () => {
     }
 
     let user8StakeAccountMetadataAddress =
-      await user8StakeConnection.getStakeMetadataAddress(
-        user8,
-      );
+      await user8StakeConnection.getStakeMetadataAddress(user8);
     let previousUser8StakeAccountCheckpointsAddress =
       await user8StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         user8StakeAccountMetadataAddress,
         false,
       );
-    let user8StakeAccountCheckpointsAddress =
-      PublicKey.findProgramAddressSync(
-        [
-          utils.bytes.utf8.encode(wasm.Constants.CHECKPOINT_DATA_SEED()),
-          user8.toBuffer(),
-          Buffer.from([1, 0]),
-        ],
-        user8StakeConnection.program.programId,
-      )[0];
+    let user8StakeAccountCheckpointsAddress = PublicKey.findProgramAddressSync(
+      [
+        utils.bytes.utf8.encode(wasm.Constants.CHECKPOINT_DATA_SEED()),
+        user8.toBuffer(),
+        Buffer.from([1, 0]),
+      ],
+      user8StakeConnection.program.programId,
+    )[0];
 
     let user6StakeAccountMetadataAddress =
-      await user6StakeConnection.getStakeMetadataAddress(
-        user6,
-      );
+      await user6StakeConnection.getStakeMetadataAddress(user6);
     let user6StakeAccountCheckpointsAddress =
       await user6StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         user6StakeAccountMetadataAddress,
@@ -597,15 +571,11 @@ describe("castVote", async () => {
     );
     instructions.push(
       await user8StakeConnection.program.methods
-        .delegate(
-          user6,
-          user8,
-        )
+        .delegate(user6, user8)
         .accountsPartial({
           currentDelegateStakeAccountCheckpoints:
             previousUser8StakeAccountCheckpointsAddress,
-          delegateeStakeAccountCheckpoints:
-            user6StakeAccountCheckpointsAddress,
+          delegateeStakeAccountCheckpoints: user6StakeAccountCheckpointsAddress,
           vestingConfig: null,
           vestingBalance: null,
           mint: user8StakeConnection.config.votingTokenMint,
@@ -617,8 +587,7 @@ describe("castVote", async () => {
         .createCheckpoints()
         .accounts({
           payer: user8,
-          stakeAccountCheckpoints:
-            previousUser8StakeAccountCheckpointsAddress,
+          stakeAccountCheckpoints: previousUser8StakeAccountCheckpointsAddress,
           newStakeAccountCheckpoints: user8StakeAccountCheckpointsAddress,
           stakeAccountMetadata: user8StakeAccountMetadataAddress,
         })
@@ -626,15 +595,11 @@ describe("castVote", async () => {
     );
     instructions.push(
       await user8StakeConnection.program.methods
-        .delegate(
-          user8,
-          user6,
-        )
+        .delegate(user8, user6)
         .accountsPartial({
           currentDelegateStakeAccountCheckpoints:
             user6StakeAccountCheckpointsAddress,
-          delegateeStakeAccountCheckpoints:
-            user8StakeAccountCheckpointsAddress,
+          delegateeStakeAccountCheckpoints: user8StakeAccountCheckpointsAddress,
           vestingConfig: null,
           vestingBalance: null,
           mint: user8StakeConnection.config.votingTokenMint,
@@ -652,11 +617,13 @@ describe("castVote", async () => {
     );
 
     let previousUser8StakeAccountCheckpoints: CheckpointAccount =
-    await user8StakeConnection.fetchCheckpointAccount(
-      previousUser8StakeAccountCheckpointsAddress,
-    );
+      await user8StakeConnection.fetchCheckpointAccount(
+        previousUser8StakeAccountCheckpointsAddress,
+      );
     assert.equal(
-      previousUser8StakeAccountCheckpoints.checkpoints[TEST_CHECKPOINTS_ACCOUNT_LIMIT - 1].value.toString(),
+      previousUser8StakeAccountCheckpoints.checkpoints[
+        TEST_CHECKPOINTS_ACCOUNT_LIMIT - 1
+      ].value.toString(),
       "0",
     );
 
@@ -686,7 +653,7 @@ describe("castVote", async () => {
     );
 
     const { proposalId, againstVotes, forVotes, abstainVotes } =
-    await user8StakeConnection.proposalVotes(proposalIdInput);
+      await user8StakeConnection.proposalVotes(proposalIdInput);
 
     assert.equal(proposalId.toString("hex"), proposalIdInput.toString("hex"));
     assert.equal(againstVotes.toString(), "10");
@@ -705,28 +672,23 @@ describe("castVote", async () => {
     }
 
     let user9StakeAccountMetadataAddress =
-      await user9StakeConnection.getStakeMetadataAddress(
-        user9,
-      );
+      await user9StakeConnection.getStakeMetadataAddress(user9);
     let previousUser9StakeAccountCheckpointsAddress =
       await user9StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         user9StakeAccountMetadataAddress,
         false,
       );
-    let user9StakeAccountCheckpointsAddress =
-      PublicKey.findProgramAddressSync(
-        [
-          utils.bytes.utf8.encode(wasm.Constants.CHECKPOINT_DATA_SEED()),
-          user9.toBuffer(),
-          Buffer.from([1, 0]),
-        ],
-        user9StakeConnection.program.programId,
-      )[0];
+    let user9StakeAccountCheckpointsAddress = PublicKey.findProgramAddressSync(
+      [
+        utils.bytes.utf8.encode(wasm.Constants.CHECKPOINT_DATA_SEED()),
+        user9.toBuffer(),
+        Buffer.from([1, 0]),
+      ],
+      user9StakeConnection.program.programId,
+    )[0];
 
     let user6StakeAccountMetadataAddress =
-      await user6StakeConnection.getStakeMetadataAddress(
-        user6,
-      );
+      await user6StakeConnection.getStakeMetadataAddress(user6);
     let user6StakeAccountCheckpointsAddress =
       await user6StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         user6StakeAccountMetadataAddress,
@@ -743,10 +705,7 @@ describe("castVote", async () => {
     );
     instructions.push(
       await user9StakeConnection.program.methods
-        .delegate(
-          user9,
-          user9,
-        )
+        .delegate(user9, user9)
         .accountsPartial({
           currentDelegateStakeAccountCheckpoints:
             previousUser9StakeAccountCheckpointsAddress,
@@ -763,8 +722,7 @@ describe("castVote", async () => {
         .createCheckpoints()
         .accounts({
           payer: user9,
-          stakeAccountCheckpoints:
-            previousUser9StakeAccountCheckpointsAddress,
+          stakeAccountCheckpoints: previousUser9StakeAccountCheckpointsAddress,
           newStakeAccountCheckpoints: user9StakeAccountCheckpointsAddress,
           stakeAccountMetadata: user9StakeAccountMetadataAddress,
         })
@@ -772,15 +730,11 @@ describe("castVote", async () => {
     );
     instructions.push(
       await user9StakeConnection.program.methods
-        .delegate(
-          user6,
-          user9,
-        )
+        .delegate(user6, user9)
         .accountsPartial({
           currentDelegateStakeAccountCheckpoints:
             user9StakeAccountCheckpointsAddress,
-          delegateeStakeAccountCheckpoints:
-            user6StakeAccountCheckpointsAddress,
+          delegateeStakeAccountCheckpoints: user6StakeAccountCheckpointsAddress,
           vestingConfig: null,
           vestingBalance: null,
           mint: user9StakeConnection.config.votingTokenMint,
@@ -856,20 +810,11 @@ describe("castVote", async () => {
 
     try {
       await user2StakeConnection.program.methods
-        .castVote(
-          Array.from(proposalId),
-          new BN(10),
-          new BN(20),
-          new BN(12),
-          1,
-        )
+        .castVote(Array.from(proposalId), new BN(10), new BN(20), new BN(12), 1)
         .accountsPartial({
           proposal: proposalAccount,
           voterCheckpoints:
-            await stakeConnection.getStakeAccountCheckpointsAddress(
-              user4,
-              0,
-            ),
+            await stakeConnection.getStakeAccountCheckpointsAddress(user4, 0),
           voterCheckpointsNext: null,
         })
         .rpc();
@@ -885,9 +830,7 @@ describe("castVote", async () => {
     let proposalIdInput;
 
     let stakeAccountMetadataAddress =
-      await user2StakeConnection.getStakeMetadataAddress(
-        user2,
-      );
+      await user2StakeConnection.getStakeMetadataAddress(user2);
     let currentStakeAccountCheckpointsAddress =
       await user2StakeConnection.getStakeAccountCheckpointsAddressByMetadata(
         stakeAccountMetadataAddress,
@@ -899,17 +842,18 @@ describe("castVote", async () => {
       );
     let checkpointCount = currentStakeAccountCheckpoints.getCheckpointCount();
 
-    assert.equal(
-      checkpointCount,
-      1,
-    );
+    assert.equal(checkpointCount, 1);
 
     // fill checkpoint account to one less than the limit
-    for (let i = 0; i < TEST_CHECKPOINTS_ACCOUNT_LIMIT - checkpointCount - 1; i++) {
+    for (
+      let i = 0;
+      i < TEST_CHECKPOINTS_ACCOUNT_LIMIT - checkpointCount - 1;
+      i++
+    ) {
       await sleep(1000);
       await user2StakeConnection.delegate(
         user2,
-        WHTokenBalance.fromString("5")
+        WHTokenBalance.fromString("5"),
       );
 
       if (i == 9) {
@@ -922,9 +866,9 @@ describe("castVote", async () => {
     }
 
     let updatedCurrentStakeAccountCheckpoints: CheckpointAccount =
-    await user2StakeConnection.fetchCheckpointAccount(
-      currentStakeAccountCheckpointsAddress,
-    );
+      await user2StakeConnection.fetchCheckpointAccount(
+        currentStakeAccountCheckpointsAddress,
+      );
     assert.equal(
       updatedCurrentStakeAccountCheckpoints.getCheckpointCount(),
       TEST_CHECKPOINTS_ACCOUNT_LIMIT - 1,

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -248,7 +248,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         NOW.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -257,7 +257,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config2.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         NOW.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -266,7 +266,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         FEW_LATER_2.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -275,7 +275,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -284,7 +284,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         EVEN_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -293,7 +293,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -302,7 +302,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         EVEN_LATER_AGAIN.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -311,7 +311,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -320,7 +320,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vester2Ta.toBuffer(),
+        vester2.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -329,7 +329,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vester3Ta.toBuffer(),
+        vester3.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -338,7 +338,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        vesterTa.toBuffer(),
+        vester.publicKey.toBuffer(),
         FEW_LATER_3.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -347,7 +347,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER_3.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -2097,7 +2097,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -2317,7 +2317,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -2407,7 +2407,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -2742,7 +2742,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -2945,7 +2945,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVester2Ta.toBuffer(),
+        newVester2.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3008,7 +3008,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVester2Ta.toBuffer(),
+        newVester2.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3162,7 +3162,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVester2Ta.toBuffer(),
+        newVester2.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3260,7 +3260,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVester2Ta.toBuffer(),
+        newVester2.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3448,7 +3448,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3644,7 +3644,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVesterTa.toBuffer(),
+        newVester.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
@@ -3706,7 +3706,7 @@ describe("vesting", () => {
       [
         Buffer.from(wasm.Constants.VEST_SEED()),
         config.toBuffer(),
-        newVester3Ta.toBuffer(),
+        newVester3.publicKey.toBuffer(),
         FEW_LATER.toBuffer("le", 8),
       ],
       stakeConnection.program.programId

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -789,7 +789,7 @@ describe("vesting", () => {
     }
   });
 
-  it("Create vesting balance", async () => {
+  it("should successfully create vesting balance account", async () => {
     await stakeConnection.program.methods
       .createVestingBalance(vester.publicKey)
       .accounts({ ...accounts, vestingBalance: vestingBalance })
@@ -798,9 +798,9 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Close and re-create vesting balance", async () => {
+  it("should successfully close and re-create vesting balance account", async () => {
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(vester.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vestingBalance,
@@ -824,7 +824,7 @@ describe("vesting", () => {
   it("should fail to close vesting balance account with incorrect rent payer", async () => {
     try {
       await stakeConnection.program.methods
-        .closeVestingBalance()
+        .closeVestingBalance(vester.publicKey)
         .accounts({
           ...accounts,
           vestingBalance: vestingBalance,
@@ -839,7 +839,7 @@ describe("vesting", () => {
     }
   });
 
-  it("Create another vesting balance", async () => {
+  it("should successfully create another vesting balance accounts", async () => {
     await stakeConnection.program.methods
       .createVestingBalance(vester2.publicKey)
       .accounts({
@@ -892,13 +892,12 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Close and re-create another vesting balance", async () => {
+  it("should successfully close and re-create another vesting balance accounts", async () => {
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(vester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting2Balance,
-        vesterTa: vester2Ta,
         rentPayer: whMintAuthority.publicKey,
       })
       .signers([whMintAuthority])
@@ -906,11 +905,10 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(vester3.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting3Balance,
-        vesterTa: vester3Ta,
         rentPayer: whMintAuthority.publicKey,
       })
       .signers([whMintAuthority])
@@ -918,11 +916,10 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(newVester.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVestingBalance,
-        vesterTa: newVesterTa,
         rentPayer: whMintAuthority.publicKey,
       })
       .signers([whMintAuthority])
@@ -930,11 +927,10 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(newVester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVesting2Balance,
-        vesterTa: newVester2Ta,
         rentPayer: whMintAuthority.publicKey,
       })
       .signers([whMintAuthority])
@@ -942,7 +938,7 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .closeVestingBalance()
+      .closeVestingBalance(vester.publicKey)
       .accounts({
         ...accounts,
         config: config2,
@@ -3595,12 +3591,11 @@ describe("vesting", () => {
   it("should fail to close vesting balance account when balance is not 0", async () => {
     try {
       await stakeConnection.program.methods
-        .closeVestingBalance()
+        .closeVestingBalance(vesterWithoutAccount.publicKey)
         .accounts({
           ...accounts,
           rentPayer: newVester.publicKey,
           vestingBalance: vestingBalanceWithoutAccount,
-          vesterTa: vesterTaWithoutAccount,
         })
         .signers([newVester])
         .rpc()

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -120,7 +120,6 @@ describe("vesting", () => {
     vester3StakeConnection,
     newVestingBalance,
     newVesting2Balance,
-    newVesting3Balance,
     vestingBalanceWithoutAccount,
     newVesterStakeConnection,
     newVester2StakeConnection,
@@ -399,14 +398,6 @@ describe("vesting", () => {
       ],
       stakeConnection.program.programId,
     )[0];
-    newVesting3Balance = PublicKey.findProgramAddressSync(
-      [
-        Buffer.from(wasm.Constants.VESTING_BALANCE_SEED()),
-        config.toBuffer(),
-        newVester3.publicKey.toBuffer(),
-      ],
-      stakeConnection.program.programId,
-    )[0];
     vestingBalanceWithoutAccount = PublicKey.findProgramAddressSync(
       [
         Buffer.from(wasm.Constants.VESTING_BALANCE_SEED()),
@@ -485,8 +476,6 @@ describe("vesting", () => {
       config,
       vault,
       vester: vester.publicKey,
-      vesterTa,
-      newVesterTa,
       adminAta,
       recovery: adminAta,
       associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -494,9 +483,8 @@ describe("vesting", () => {
       systemProgram: SystemProgram.programId,
       vestingBalance: vestingBalance,
     };
-  });
 
-  it("Airdrop", async () => {
+    // Airdrop
     let tx = new Transaction();
     tx.instructions = [
       ...[whMintAuthority, vester, vester2, vester3, fakeVestingAdmin].map(
@@ -720,7 +708,7 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Initialize config", async () => {
+  it("should successfully initialize config", async () => {
     await stakeConnection.program.methods
       .initializeVestingConfig(seed)
       .accounts({ ...accounts })
@@ -1141,6 +1129,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestNow,
           delegateStakeAccountCheckpoints: null,
           delegateStakeAccountMetadata: null,
@@ -1196,7 +1185,7 @@ describe("vesting", () => {
     }
   });
 
-  it("Deposits vesting tokens", async () => {
+  it("should successfully deposit vesting tokens", async () => {
     const tx = new Transaction();
     tx.add(
       createTransferCheckedInstruction(
@@ -1265,7 +1254,7 @@ describe("vesting", () => {
     }
   });
 
-  it("Withdraw surplus tokens", async () => {
+  it("should successfully withdraw surplus tokens", async () => {
     await stakeConnection.program.methods
       .withdrawSurplus()
       .accounts({ ...accounts })
@@ -1274,7 +1263,7 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Finalizes the vesting config2", async () => {
+  it("should successfully finalize the second vesting config", async () => {
     await stakeConnection.program.methods
       .finalizeVestingConfig()
       .accounts({
@@ -1322,6 +1311,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestEvenLater,
           delegateStakeAccountCheckpoints: null,
           delegateStakeAccountMetadata: null,
@@ -1659,6 +1649,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestNow,
           delegateStakeAccountCheckpoints: null,
           delegateStakeAccountMetadata: null,
@@ -1685,6 +1676,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestNow,
           delegateStakeAccountCheckpoints: null,
           delegateStakeAccountMetadata: stakeAccountMetadataAddress,
@@ -1718,6 +1710,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestNow,
           delegateStakeAccountCheckpoints:
             incorrectStakeAccountCheckpointsAddress,
@@ -1757,6 +1750,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestNow,
           delegateStakeAccountCheckpoints:
             incorrectStakeAccountCheckpointsAddress,
@@ -1846,6 +1840,7 @@ describe("vesting", () => {
       .claimVesting()
       .accounts({
         ...accounts,
+        vesterTa,
         vest: vestNow,
         delegateStakeAccountCheckpoints: delegateStakeAccountCheckpointsAddress,
         delegateStakeAccountMetadata: stakeAccountMetadataAddress,
@@ -1982,6 +1977,7 @@ describe("vesting", () => {
         .claimVesting()
         .accounts({
           ...accounts,
+          vesterTa,
           vest: vestFewLater,
           delegateStakeAccountCheckpoints:
             delegateStakeAccountCheckpointsAddress,
@@ -2452,6 +2448,7 @@ describe("vesting", () => {
       .claimVesting()
       .accounts({
         ...accounts,
+        vesterTa,
         vest: vestFewLater,
         delegateStakeAccountCheckpoints: delegateStakeAccountCheckpointsAddress,
         delegateStakeAccountMetadata: stakeAccountMetadataAddress,

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -69,6 +69,7 @@ describe("vesting", () => {
   const FEW_LATER_2 = NOW.add(new BN(2));
   const FEW_LATER_3 = NOW.add(new BN(3));
   const LATER = NOW.add(new BN(1000));
+  const LATER2 = LATER.add(new BN(20));
   const EVEN_LATER = LATER.add(new BN(1000));
   const EVEN_LATER_AGAIN = EVEN_LATER.add(new BN(1000));
 
@@ -104,6 +105,7 @@ describe("vesting", () => {
     vestNow2,
     vestEvenLater,
     vestLater,
+    vestLaterForCancel,
     vestLaterForTransfer,
     vestEvenLaterAgain,
     vestNowForTransfer,
@@ -277,6 +279,15 @@ describe("vesting", () => {
         config.toBuffer(),
         vester.publicKey.toBuffer(),
         LATER.toBuffer("le", 8),
+      ],
+      stakeConnection.program.programId,
+    )[0];
+    vestLaterForCancel = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from(wasm.Constants.VEST_SEED()),
+        config.toBuffer(),
+        vester.publicKey.toBuffer(),
+        LATER2.toBuffer("le", 8),
       ],
       stakeConnection.program.programId,
     )[0];
@@ -1035,7 +1046,7 @@ describe("vesting", () => {
     }
   });
 
-  it("Create a matured vest", async () => {
+  it("should successfully create a matured vest", async () => {
     await stakeConnection.program.methods
       .createVesting(NOW, new BN(1237e6))
       .accounts({ ...accounts, vest: vestNow })
@@ -1046,7 +1057,7 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Create another matured vests", async () => {
+  it("should successfully create another matured vests", async () => {
     await stakeConnection.program.methods
       .createVesting(NOW, new BN(100e6))
       .accounts({
@@ -1131,16 +1142,21 @@ describe("vesting", () => {
       .then(confirm);
   });
 
-  it("Create an unmatured vest", async () => {
+  it("should successfully сreate unmatured vests", async () => {
     await stakeConnection.program.methods
       .createVesting(LATER, new BN(1337e6))
       .accounts({ ...accounts, vest: vestLater })
       .signers([whMintAuthority])
       .rpc({ skipPreflight: true })
       .then(confirm);
-  });
 
-  it("Create another unmatured vest", async () => {
+    await stakeConnection.program.methods
+      .createVesting(LATER2, new BN(1337e6))
+      .accounts({ ...accounts, vest: vestLaterForCancel })
+      .signers([whMintAuthority])
+      .rpc({ skipPreflight: true })
+      .then(confirm);
+
     await stakeConnection.program.methods
       .createVesting(EVEN_LATER, new BN(1337e6))
       .accounts({
@@ -1178,13 +1194,104 @@ describe("vesting", () => {
     }
   });
 
-  it("Cancel a vest", async () => {
+  it("should successfully cancel a vest", async () => {
     await stakeConnection.program.methods
       .cancelVesting()
       .accounts({ ...accounts, vest: vestLater })
       .signers([whMintAuthority])
       .rpc({ skipPreflight: true })
       .then(confirm);
+  });
+
+  it("should successfully cancel a vest with changed token account owner", async () => {
+    // change vesterTa owner to newVester
+    let tx = new Transaction();
+    tx.add(
+      createSetAuthorityInstruction(
+        vesterTa,
+        vester.publicKey,
+        AuthorityType.AccountOwner,
+        newVester.publicKey,
+      ),
+    );
+    await stakeConnection.provider.sendAndConfirm(tx, [vester]);
+
+    try {
+      // attempt to cancel vesting with original vest account
+      await stakeConnection.program.methods
+        .cancelVesting()
+        .accounts({ ...accounts, vest: vestLaterForCancel })
+        .signers([whMintAuthority])
+        .rpc()
+        .then(confirm);
+
+      assert.fail("Expected error was not thrown");
+    } catch (e) {
+      // expect failure due to seeds mismatch after owner change
+      assert(
+        (e as AnchorError).error?.errorCode?.code === "ConstraintSeeds",
+      );
+    }
+
+    // create randomKeypairTa
+    const randomKeypair = Keypair.generate();
+    let randomKeypairTa = getAssociatedTokenAddressSync(
+      whMintAccount.publicKey,
+      randomKeypair.publicKey,
+      false,
+      TOKEN_PROGRAM_ID,
+    );
+    tx = new Transaction();
+    tx.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        whMintAuthority.publicKey,
+        randomKeypairTa,
+        randomKeypair.publicKey,
+        whMintAccount.publicKey,
+      ),
+    );
+    await stakeConnection.provider.sendAndConfirm(tx, [whMintAuthority]);
+
+    // change randomKeypairTa owner to vester
+    tx = new Transaction();
+    tx.add(
+      createSetAuthorityInstruction(
+        randomKeypairTa,
+        randomKeypair.publicKey,
+        AuthorityType.AccountOwner,
+        vester.publicKey,
+      )
+    );
+    await stakeConnection.provider.sendAndConfirm(tx, [randomKeypair]);
+
+    const randomKeypairTaAccount = await getAccount(stakeConnection.provider.connection, randomKeypairTa);
+    assert.equal(
+      randomKeypairTaAccount.owner.toBase58(),
+      vester.publicKey.toBase58(),
+      "The owner of randomKeypairTaAccount should be vester"
+    );
+
+    await stakeConnection.program.methods
+    .cancelVesting()
+    .accounts({
+      ...accounts,
+      vest: vestLaterForCancel,
+      vesterTa: randomKeypairTa,
+    })
+    .signers([whMintAuthority])
+    .rpc();
+
+    // restore original vesterTa owner for cleanup
+    tx = new Transaction();
+    tx.add(
+      createSetAuthorityInstruction(
+        vesterTa,
+        newVester.publicKey,
+        AuthorityType.AccountOwner,
+        vester.publicKey,
+      )
+    );
+    await stakeConnection.provider.sendAndConfirm(tx, [newVester]);
   });
 
   it("should fail to finalize vesting when vault token balance is less than vestingConfig.vested", async () => {

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -2086,7 +2086,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2228,7 +2228,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2306,7 +2306,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2396,7 +2396,7 @@ describe("vesting", () => {
 
     try {
       await vesterStakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2610,7 +2610,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2650,7 +2650,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2685,7 +2685,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(vester.publicKey)
         .accounts({
           ...accounts,
           vest: vestNowForTransfer,
@@ -2693,8 +2693,6 @@ describe("vesting", () => {
           delegateStakeAccountMetadata: stakeAccountMetadataAddress,
           stakeAccountMetadata: stakeAccountMetadataAddress,
           newStakeAccountMetadata: stakeAccountMetadataAddress,
-          vesterTa: vesterTa,
-          newVesterTa: vesterTa,
           newVest: vestNowForTransfer,
           newVestingBalance: vestingBalance,
           globalConfig: stakeConnection.configAddress,
@@ -2825,7 +2823,7 @@ describe("vesting", () => {
         })
         .instruction(),
       await vesterStakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           payer: vester.publicKey,
@@ -2934,12 +2932,10 @@ describe("vesting", () => {
 
     try {
       await vester2StakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester2.publicKey)
         .accounts({
           ...accounts,
           vester: vester2.publicKey,
-          vesterTa: vester2Ta,
-          newVesterTa: newVester2Ta,
           vest: vest2NowForTransfer,
           vestingBalance: vesting2Balance,
           delegateStakeAccountCheckpoints:
@@ -3027,12 +3023,10 @@ describe("vesting", () => {
 
     await sleep(1500);
     await vester2StakeConnection.program.methods
-      .transferVesting()
+      .transferVesting(newVester2.publicKey)
       .accounts({
         ...accounts,
         vester: vester2.publicKey,
-        vesterTa: vester2Ta,
-        newVesterTa: newVester2Ta,
         vest: vest2NowForTransfer,
         vestingBalance: vesting2Balance,
         delegateStakeAccountCheckpoints: null,
@@ -3356,7 +3350,7 @@ describe("vesting", () => {
         })
         .instruction(),
       await vesterStakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           payer: vester.publicKey,
@@ -3533,11 +3527,10 @@ describe("vesting", () => {
     await sleep(1500);
     // transfer vestLaterForTransfer from newVester to vesterWithoutAccount
     await stakeConnection.program.methods
-      .transferVesting()
+      .transferVesting(vesterWithoutAccount.publicKey)
       .accounts({
         ...accounts,
         vester: newVester.publicKey,
-        vesterTa: newVesterTa,
         vestingBalance: newVestingBalance,
         vest: vestLaterForTransfer,
         delegateStakeAccountCheckpoints:
@@ -3546,7 +3539,6 @@ describe("vesting", () => {
         stakeAccountMetadata: newVesterStakeAccountMetadataAddress,
         newStakeAccountMetadata: null,
         newVestingBalance: vestingBalanceWithoutAccount,
-        newVesterTa: vesterTaWithoutAccount,
         globalConfig: stakeConnection.configAddress,
       })
       .signers([newVester])
@@ -3632,7 +3624,7 @@ describe("vesting", () => {
 
     try {
       await vester3StakeConnection.program.methods
-        .transferVesting()
+        .transferVesting(newVester.publicKey)
         .accounts({
           ...accounts,
           vester: vester3.publicKey,
@@ -3642,8 +3634,6 @@ describe("vesting", () => {
           delegateStakeAccountMetadata: null,
           stakeAccountMetadata: stakeAccountMetadataAddress,
           newStakeAccountMetadata: newVesterStakeAccountMetadataAddress,
-          vesterTa: vester3Ta,
-          newVesterTa: newVesterTa,
           newVest: vestNowTransfered,
           newVestingBalance: newVestingBalance,
           globalConfig: vester3StakeConnection.configAddress,
@@ -3658,78 +3648,6 @@ describe("vesting", () => {
         (e as AnchorError).error?.errorCode?.code === "ErrorOfAccountParsing",
       );
     }
-  });
-
-  it("should fail to transfer vest if vester_ta is frozen", async () => {
-    let freezeTx = new Transaction();
-    freezeTx.add(
-      createFreezeAccountInstruction(
-        vester3Ta,
-        whMintAccount.publicKey,
-        whMintAuthority.publicKey,
-      )
-    );
-    await stakeConnection.provider.sendAndConfirm(freezeTx, [whMintAuthority]);
-
-    let vester3TaAccount = await getAccount(stakeConnection.provider.connection, vester3Ta);
-    assert.equal(vester3TaAccount.isFrozen, true, "vester3Ta should be frozen");
-
-    let stakeAccountMetadataAddress = await vester3StakeConnection.getStakeMetadataAddress(
-      vester3.publicKey
-    );
-    let newVester3StakeAccountMetadataAddress =
-      await newVester3StakeConnection.getStakeMetadataAddress(
-        newVester3.publicKey,
-      );
-
-    let newVester3Vest = PublicKey.findProgramAddressSync(
-      [
-        Buffer.from(wasm.Constants.VEST_SEED()),
-        config.toBuffer(),
-        newVester3.publicKey.toBuffer(),
-        FEW_LATER.toBuffer("le", 8),
-      ],
-      stakeConnection.program.programId
-    )[0];
-
-    try {
-      await vesterStakeConnection.program.methods
-        .transferVesting()
-        .accounts({
-          ...accounts,
-          vester: vester3.publicKey,
-          vest: vest3NowForTransfer,
-          vestingBalance: vesting3Balance,
-          delegateStakeAccountCheckpoints: null,
-          delegateStakeAccountMetadata: null,
-          stakeAccountMetadata: stakeAccountMetadataAddress,
-          newStakeAccountMetadata: newVester3StakeAccountMetadataAddress,
-          vesterTa: vester3Ta,
-          newVesterTa: newVester3Ta,
-          newVest: newVester3Vest,
-          newVestingBalance: newVesting3Balance,
-          globalConfig: vester3StakeConnection.configAddress,
-        })
-        .signers([vester3])
-        .rpc()
-        .then(confirm);
-
-      assert.fail("Expected error was not thrown");
-    } catch (e) {
-      assert(
-        (e as AnchorError).error?.errorCode?.code === "FrozenVesterAccount",
-      );
-    }
-
-    let thawTx = new Transaction();
-    thawTx.add(
-      createThawAccountInstruction(
-        vester3Ta,
-        whMintAccount.publicKey,
-        whMintAuthority.publicKey,
-      )
-    );
-    await stakeConnection.provider.sendAndConfirm(thawTx, [whMintAuthority]);
   });
 
   it("should confirm that the owner of vester3Ta can be changed", async () => {

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -684,15 +684,16 @@ describe("vesting", () => {
     const tx = new Transaction();
     tx.add(
       createAssociatedTokenAccountInstruction(
-        vester.publicKey,        // payer
-        vault3,                  // associatedToken
-        config3,                 // owner
+        vester.publicKey, // payer
+        vault3, // associatedToken
+        config3, // owner
         whMintAccount.publicKey, // mint
         TOKEN_PROGRAM_ID,
         ASSOCIATED_TOKEN_PROGRAM_ID,
       ),
     );
-    await vesterStakeConnection.provider.sendAndConfirm(tx, [vester])
+    await vesterStakeConnection.provider
+      .sendAndConfirm(tx, [vester])
       .then(confirm);
     await sleep(1500);
 
@@ -3648,17 +3649,20 @@ describe("vesting", () => {
   });
 
   it("should confirm that the owner of vester3Ta can be changed", async () => {
-    const vester3TaAccountInitial = await getAccount(stakeConnection.provider.connection, vester3Ta);
+    const vester3TaAccountInitial = await getAccount(
+      stakeConnection.provider.connection,
+      vester3Ta,
+    );
     assert.equal(
       vester3TaAccountInitial.owner.toBase58(),
       vester3.publicKey.toBase58(),
-      "Initial owner of vester3Ta should be vester3"
+      "Initial owner of vester3Ta should be vester3",
     );
 
     const newOwner = newVester3.publicKey;
     assert.notEqual(
       vester3TaAccountInitial.owner.toBase58(),
-      newOwner.toBase58()
+      newOwner.toBase58(),
     );
 
     const setAuthorityTx = new Transaction();
@@ -3668,15 +3672,18 @@ describe("vesting", () => {
         vester3.publicKey,
         AuthorityType.AccountOwner,
         newOwner,
-      )
+      ),
     );
     await stakeConnection.provider.sendAndConfirm(setAuthorityTx, [vester3]);
-  
-    const vester3TaAccountAfter = await getAccount(stakeConnection.provider.connection, vester3Ta);
+
+    const vester3TaAccountAfter = await getAccount(
+      stakeConnection.provider.connection,
+      vester3Ta,
+    );
     assert.equal(
       vester3TaAccountAfter.owner.toBase58(),
       newOwner.toBase58(),
-      "The owner of vester3Ta should change"
+      "The owner of vester3Ta should change",
     );
   });
 

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -1016,7 +1016,7 @@ describe("vesting", () => {
   it("should fail to create vest with invalid admin", async () => {
     try {
       await stakeConnection.program.methods
-        .createVesting(NOW, new BN(1337e6))
+        .createVesting(vester.publicKey, NOW, new BN(1337e6))
         .accounts({
           ...accounts,
           vest: vestNow,
@@ -1036,7 +1036,7 @@ describe("vesting", () => {
 
   it("should successfully create a matured vest", async () => {
     await stakeConnection.program.methods
-      .createVesting(NOW, new BN(1237e6))
+      .createVesting(vester.publicKey, NOW, new BN(1237e6))
       .accounts({ ...accounts, vest: vestNow })
       .signers([whMintAuthority])
       .rpc({
@@ -1047,7 +1047,7 @@ describe("vesting", () => {
 
   it("should successfully create another matured vests", async () => {
     await stakeConnection.program.methods
-      .createVesting(NOW, new BN(100e6))
+      .createVesting(vester.publicKey, NOW, new BN(100e6))
       .accounts({
         ...accounts,
         config: config2,
@@ -1061,18 +1061,17 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER, new BN(1016e6))
+      .createVesting(vester.publicKey, FEW_LATER, new BN(1016e6))
       .accounts({ ...accounts, vest: vestNowForTransfer })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER, new BN(1016e6))
+      .createVesting(vester2.publicKey, FEW_LATER, new BN(1016e6))
       .accounts({
         ...accounts,
         vest: vest2NowForTransfer,
-        vesterTa: vester2Ta,
         vestingBalance: vesting2Balance,
       })
       .signers([whMintAuthority])
@@ -1080,11 +1079,10 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER, new BN(1016e6))
+      .createVesting(vester3.publicKey, FEW_LATER, new BN(1016e6))
       .accounts({
         ...accounts,
         vest: vest3NowForTransfer,
-        vesterTa: vester3Ta,
         vestingBalance: vesting3Balance,
       })
       .signers([whMintAuthority])
@@ -1092,18 +1090,17 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER_3, new BN(321e6))
+      .createVesting(vester.publicKey, FEW_LATER_3, new BN(321e6))
       .accounts({ ...accounts, vest: vestNowForTransfer3 })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER_3, new BN(321e6))
+      .createVesting(newVester.publicKey, FEW_LATER_3, new BN(321e6))
       .accounts({
         ...accounts,
         vest: vestNowTransfered3,
-        vesterTa: newVesterTa,
         vestingBalance: newVestingBalance,
       })
       .signers([whMintAuthority])
@@ -1111,11 +1108,10 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(LATER, new BN(1016e6))
+      .createVesting(newVester.publicKey, LATER, new BN(1016e6))
       .accounts({
         ...accounts,
         vest: vestLaterForTransfer,
-        vesterTa: newVesterTa,
         vestingBalance: newVestingBalance,
       })
       .signers([whMintAuthority])
@@ -1123,7 +1119,7 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(FEW_LATER_2, new BN(1337e6))
+      .createVesting(vester.publicKey, FEW_LATER_2, new BN(1337e6))
       .accounts({ ...accounts, vest: vestFewLater })
       .signers([whMintAuthority])
       .rpc()
@@ -1132,14 +1128,14 @@ describe("vesting", () => {
 
   it("should successfully сreate unmatured vests", async () => {
     await stakeConnection.program.methods
-      .createVesting(LATER, new BN(1337e6))
+      .createVesting(vester.publicKey, LATER, new BN(1337e6))
       .accounts({ ...accounts, vest: vestLater })
       .signers([whMintAuthority])
       .rpc({ skipPreflight: true })
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVesting(EVEN_LATER, new BN(1337e6))
+      .createVesting(vester.publicKey, EVEN_LATER, new BN(1337e6))
       .accounts({
         ...accounts,
         vest: vestEvenLater,
@@ -1320,7 +1316,7 @@ describe("vesting", () => {
   it("should fail to create a vest after finalize", async () => {
     try {
       await stakeConnection.program.methods
-        .createVesting(EVEN_LATER_AGAIN, new BN(1337e6))
+        .createVesting(vester.publicKey, EVEN_LATER_AGAIN, new BN(1337e6))
         .accounts({ ...accounts, vest: vestEvenLaterAgain })
         .signers([whMintAuthority])
         .rpc()

--- a/solana/tests/vesting.ts
+++ b/solana/tests/vesting.ts
@@ -743,7 +743,7 @@ describe("vesting", () => {
   it("should fail to create vesting balance with invalid admin", async () => {
     try {
       await stakeConnection.program.methods
-        .createVestingBalance()
+        .createVestingBalance(vester.publicKey)
         .accounts({
           ...accounts,
           vestingBalance: vestingBalance,
@@ -770,7 +770,7 @@ describe("vesting", () => {
 
     try {
       await stakeConnection.program.methods
-        .createVestingBalance()
+        .createVestingBalance(vester.publicKey)
         .accounts({
           ...accounts,
           vestingBalance: vestingBalance,
@@ -791,7 +791,7 @@ describe("vesting", () => {
 
   it("Create vesting balance", async () => {
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester.publicKey)
       .accounts({ ...accounts, vestingBalance: vestingBalance })
       .signers([whMintAuthority])
       .rpc()
@@ -811,7 +811,7 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vestingBalance,
@@ -841,51 +841,47 @@ describe("vesting", () => {
 
   it("Create another vesting balance", async () => {
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting2Balance,
-        vesterTa: vester2Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester3.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting3Balance,
-        vesterTa: vester3Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(newVester.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVestingBalance,
-        vesterTa: newVesterTa,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(newVester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVesting2Balance,
-        vesterTa: newVester2Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester.publicKey)
       .accounts({
         ...accounts,
         config: config2,
@@ -958,51 +954,47 @@ describe("vesting", () => {
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting2Balance,
-        vesterTa: vester2Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester3.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: vesting3Balance,
-        vesterTa: vester3Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(newVester.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVestingBalance,
-        vesterTa: newVesterTa,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(newVester2.publicKey)
       .accounts({
         ...accounts,
         vestingBalance: newVesting2Balance,
-        vesterTa: newVester2Ta,
       })
       .signers([whMintAuthority])
       .rpc()
       .then(confirm);
 
     await stakeConnection.program.methods
-      .createVestingBalance()
+      .createVestingBalance(vester.publicKey)
       .accounts({
         ...accounts,
         config: config2,


### PR DESCRIPTION
This pull request addresses an issue in the vesting-related instructions (CreateVesting, CancelVesting, ClaimVesting and TransferVesting) where the vest account's validation and seeds were incorrectly tied to the vester_ta token account key directly. The previous implementation used has_one = vester_ta and included vester_ta.key() in the seeds, which was problematic because the owner of the vester_ta token account (vester_ta.owner) can change over time due to token account ownership transfers. This could lead to inconsistencies between the vest account's expected owner and the actual vester_ta.owner, breaking the program's logic.

