### PR TITLE
[evm] use messageFee > 0 in tests

### DIFF
--- a/evm/Dockerfile
+++ b/evm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundry-rs/foundry@sha256:8b843eb65cc7b155303b316f65d27173c862b37719dc095ef3a2ef27ce8d3c00 as builder
+FROM ghcr.io/foundry-rs/foundry:stable as builder
 
 WORKDIR /app
 COPY foundry.toml foundry.toml

--- a/evm/test/HubMessageDispatcher.t.sol
+++ b/evm/test/HubMessageDispatcher.t.sol
@@ -56,7 +56,7 @@ contract Dispatch is HubMessageDispatcherTest {
     bytes memory payload = abi.encode(
       _wormholeChainId, builder.targets(), builder.values(), builder.calldatas(), keccak256(bytes(_description))
     );
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
     assertEq(
       wormholeCoreMock.ghostPublishMessagePayload(),
       abi.encode(nextMessageId, _wormholeChainId, builder.targets(), builder.values(), builder.calldatas())
@@ -74,7 +74,7 @@ contract Dispatch is HubMessageDispatcherTest {
     bytes memory payload = abi.encode(
       _wormholeChainId, builder.targets(), builder.values(), builder.calldatas(), keccak256(bytes(_description))
     );
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
     assertEq(
       wormholeCoreMock.ghostPublishMessagePayload(),
       abi.encode(nextMessageId, _wormholeChainId, builder.targets(), builder.values(), builder.calldatas())
@@ -96,7 +96,7 @@ contract Dispatch is HubMessageDispatcherTest {
 
     vm.expectEmit();
     emit IMessageDispatcher.MessageDispatched(nextMessageId, emittedPayload);
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
   }
 
   function testFuzz_RevertIf_ProposalDataIsDifferentLengths(

--- a/evm/test/HubSolanaMessageDispatcher.t.sol
+++ b/evm/test/HubSolanaMessageDispatcher.t.sol
@@ -76,7 +76,7 @@ contract Dispatch is HubSolanaMessageDispatcherTest {
     bytes memory payload = abi.encode(CHAIN_ID_SOLANA, instructions);
     bytes memory emittedPayload = abi.encode(nextMessageId, CHAIN_ID_SOLANA, instructions);
 
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
 
     assertEq(wormholeCoreMock.ghostPublishMessagePayload(), emittedPayload);
   }
@@ -101,7 +101,7 @@ contract Dispatch is HubSolanaMessageDispatcherTest {
     bytes memory payload = abi.encode(CHAIN_ID_SOLANA, instructions);
     bytes memory emittedPayload = abi.encode(nextMessageId, CHAIN_ID_SOLANA, instructions);
 
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
 
     assertEq(wormholeCoreMock.ghostPublishMessagePayload(), emittedPayload);
   }
@@ -125,7 +125,7 @@ contract Dispatch is HubSolanaMessageDispatcherTest {
 
     vm.expectEmit();
     emit IMessageDispatcher.MessageDispatched(nextMessageId, emittedPayload);
-    dispatcher.dispatch(payload);
+    dispatcher.dispatch{value: wormholeCoreMock.messageFee()}(payload);
   }
 
   function test_RevertIf_EmptyInstructionSet() public {

--- a/evm/test/mocks/WormholeCoreMock.sol
+++ b/evm/test/mocks/WormholeCoreMock.sol
@@ -9,7 +9,7 @@ contract WormholeCoreMock is WormholeMock {
   bytes public ghostPublishMessagePayload;
   uint8 public ghostPublishMessageConsistencyLevel;
   uint16 public override chainId;
-  uint256 public immutable override messageFee;
+  uint256 public override messageFee;
 
   constructor(uint16 _chainId) {
     chainId = _chainId;

--- a/evm/test/mocks/WormholeCoreMock.sol
+++ b/evm/test/mocks/WormholeCoreMock.sol
@@ -9,9 +9,11 @@ contract WormholeCoreMock is WormholeMock {
   bytes public ghostPublishMessagePayload;
   uint8 public ghostPublishMessageConsistencyLevel;
   uint16 public override chainId;
+  uint256 public immutable override messageFee;
 
   constructor(uint16 _chainId) {
     chainId = _chainId;
+    messageFee = 1;
   }
 
   function publishMessage(uint32 _nonce, bytes memory _payload, uint8 _consistencyLevel)
@@ -20,6 +22,7 @@ contract WormholeCoreMock is WormholeMock {
     override
     returns (uint64)
   {
+    require(msg.value == messageFee, "WormholeCoreMock: Invalid message fee");
     ghostPublishMessageNonce = _nonce;
     ghostPublishMessagePayload = _payload;
     ghostPublishMessageConsistencyLevel = _consistencyLevel;

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,5 +1,5 @@
 # First stage: Build contracts
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry@sha256:8b843eb65cc7b155303b316f65d27173c862b37719dc095ef3a2ef27ce8d3c00 as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:stable as foundry
 
 # Only copy what's needed for forge build
 WORKDIR /app/evm


### PR DESCRIPTION
Core bridge integration works fine, this PR is just adding a `messageFee` > 0 in the `WormholeCoreMock` just to make sure that future features are tested against this setting.